### PR TITLE
Add invisible category: operator-guides

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -148,7 +148,7 @@ module.exports = {
 
       resolve: 'gatsby-plugin-sitemap',
       options: {
-        exclude: ['/styleguide', '/thanks-for-the-feedback'],
+        exclude: ['/styleguide', '/thanks-for-the-feedback', `/operator-guides/*`],
         serialize: ({ site, allSitePage }) => {
           return allSitePage.edges.map(edge => {
             return {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -32,7 +32,7 @@ const flatten = (array, depth = 1) => {
 
 const allowedCategoryIds = flatten(
   siteStructure.map(flattenSubcategories)
-).concat('background', 'guides', 'tutorials');
+).concat('operator-guides');
 
 // Uncomment to warn about circular dependencies.
 //

--- a/src/pages/operator-guides.js
+++ b/src/pages/operator-guides.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { StaticQuery, graphql } from 'gatsby';
+
+import { dev, siteStructure } from '../config';
+import { findSortingArrays } from '../util/navigation';
+import { ArticleIndexPage } from '../components';
+
+const category = 'operator-guides';
+// TODO const sortingArray = findSortingArrays(category, siteStructure);
+
+const query = graphql`
+  query OperatorGuidesIndexQuery {
+    allMarkdownRemark(
+      filter: { frontmatter: { category: { in: ["operator-guides"] } } }
+      sort: { fields: fileAbsolutePath, order: ASC }
+    ) {
+      edges {
+        node {
+          frontmatter {
+            title
+            slug
+            category
+            updated
+            ingress
+            published
+          }
+        }
+      }
+    }
+  }
+`;
+
+const byArrayOfSlugs = sortingArray => (a, b) => {
+  const indexA = sortingArray.indexOf(a.slug);
+  const indexB = sortingArray.indexOf(b.slug);
+
+  // If sorting array doesn't contain slug,
+  // we'll push it to the end of the array.
+  const defaultPlacement = sortingArray.length;
+  const i1 = indexA > -1 ? indexA : defaultPlacement;
+  const i2 = indexB > -1 ? indexB : defaultPlacement;
+
+  return i1 - i2;
+};
+
+const OperatorGuidesPage = () => {
+  return (
+    <StaticQuery
+      query={query}
+      render={data => {
+        const edges = data.allMarkdownRemark
+          ? data.allMarkdownRemark.edges
+          : [];
+        const articles = edges
+          .reduce((result, edge) => {
+            const { frontmatter } = edge.node;
+            if (dev || frontmatter.published) {
+              return result.concat(frontmatter);
+            } else {
+              return result;
+            }
+          }, []);
+          // TODO .sort(byArrayOfSlugs(sortingArray));
+
+        return (
+          <ArticleIndexPage category={category} noPrefix articles={articles} />
+        );
+      }}
+    />
+  );
+};
+
+export default OperatorGuidesPage;

--- a/src/ui-texts.json
+++ b/src/ui-texts.json
@@ -78,8 +78,8 @@
   "ArticleIndexPage.references.title": "All Reference articles",
   "ArticleIndexPage.references.description": "Technical reference to the tooling.",
 
-  "ArticleIndexPage.guides.title": "All How-to Guides",
-  "ArticleIndexPage.guides.description": "Specific step-by-step guides for customizing your marketplace.",
+  "ArticleIndexPage.operator-guides.title": "All Operator Guides",
+  "ArticleIndexPage.operator-guides.description": "Guides for marketplace operators",
 
   "ArticlePage.tableOfContents": "Table of Contents",
   "ArticlePage.introduction.breadCrumbTitle": "Introduction",
@@ -93,7 +93,7 @@
   "ArticlePage.integrations.breadCrumbTitle": "Integrations",
   "ArticlePage.flex-cli.breadCrumbTitle": "Flex CLI",
   "ArticlePage.references.breadCrumbTitle": "References",
-  "ArticlePage.guides.breadCrumbTitle": "How-to Guides",
+  "ArticlePage.operator-guides.breadCrumbTitle": "Operator Guides",
   "ArticlePage.LastUpdated.lastUpdated": "Last updated ",
   "ArticlePage.InfoSection.requiredSkills": "Required skills",
 


### PR DESCRIPTION
Creates "operator-guides" category, which is not visible on navigation or sitemap.xml (and therefore it's hopefully not visible in Algolia-indexed search)

And this also adds index page for the aforementioned category.