### PR TITLE
Update docs to match sharetribe-scripts v4 change

### DIFF
--- a/src/docs/cookbook-data-model/extend-listing-data-in-ftw/index.md
+++ b/src/docs/cookbook-data-model/extend-listing-data-in-ftw/index.md
@@ -256,7 +256,7 @@ component:
         ├── index.js
         └── EditListingCapacityForm
             ├── EditListingCapacityForm.js
-            └── EditListingCapacityForm.css
+            └── EditListingCapacityForm.module.css
 ```
 
 ```jsx
@@ -274,9 +274,9 @@ import { propTypes } from '../../util/types';
 import { required } from '../../util/validators';
 import { Form, Button, FieldSelect } from '../../components';
 
-// Create this file using EditListingFeaturesForm.css
+// Create this file using EditListingFeaturesForm.module.css
 // as a template.
-import css from './EditListingCapacityForm.css';
+import css from './EditListingCapacityForm.module.css';
 
 export const EditListingCapacityFormComponent = props => (
   <FinalForm
@@ -387,7 +387,7 @@ call `EditListingCapacityPanel`:
         ├── index.js
         └── EditListingCapacityForm
             ├── EditListingCapacityPanel.js
-            └── EditListingCapacityPanel.css
+            └── EditListingCapacityPanel.module.css
 ```
 
 ```jsx
@@ -401,9 +401,9 @@ import { ListingLink } from '../../components';
 import { EditListingCapacityForm } from '../../forms';
 import config from '../../config.js';
 
-// Create this file using EditListingDescriptionPanel.css
+// Create this file using EditListingDescriptionPanel.module.css
 // as a template.
-import css from './EditListingCapacityPanel.css';
+import css from './EditListingCapacityPanel.module.css';
 
 const EditListingCapacityPanel = props => {
   const {
@@ -564,7 +564,7 @@ conflicts. So, let's create a `SectionCapacity` component in the
         └── ListingPage
             ├── SectionCapacity.js
             ├── ListingPage.js
-            └── ListingPage.css
+            └── ListingPage.module.css
 ```
 
 ```jsx
@@ -572,7 +572,7 @@ import React from 'react';
 import { array, shape, string } from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import css from './ListingPage.css';
+import css from './ListingPage.module.css';
 
 const SectionCapacity = props => {
   const { publicData, options } = props;
@@ -602,9 +602,10 @@ SectionCapacity.propTypes = {
 export default SectionCapacity;
 ```
 
-Remember to add corresponding css definitions to `ListingPage.css` to
-get the styling right. Import the component into `ListingPage` and place
-it inside the `<div className={css.mainContent}>` element:
+Remember to add corresponding css definitions to
+`ListingPage.module.css` to get the styling right. Import the component
+into `ListingPage` and place it inside the
+`<div className={css.mainContent}>` element:
 
 ```js
 import SectionCapacity from './SectionCapacity';

--- a/src/docs/cookbook-design/customize-image-sizes/index.md
+++ b/src/docs/cookbook-design/customize-image-sizes/index.md
@@ -151,7 +151,7 @@ defined image variants. In `ListingCard` perform the following change:
     └── components
         └── ListingCard
             └── ListingCard.js
-            └── ListingCard.css
+            └── ListingCard.module.css
 ```
 
 ```diff
@@ -165,7 +165,7 @@ defined image variants. In `ListingCard` perform the following change:
 />
 ```
 
-Finally, update the aspect ratio in `ListingCard.css`:
+Finally, update the aspect ratio in `ListingCard.module.css`:
 
 ```diff
 .aspectWrapper {

--- a/src/docs/ftw-search/how-to-use-google-maps-in-ftw/index.md
+++ b/src/docs/ftw-search/how-to-use-google-maps-in-ftw/index.md
@@ -118,9 +118,9 @@ Furthermore, Google Map states in their terms of service that Google
 logo needs to be visible when using their geocoding service. It is
 available as a background image below the autocomplete predictions.
 However, there needs to be enough padding for that logo. You can change
-the padding through `marketplace.css`.
+the padding through `marketplaceDefaults.css`.
 
-_src/marketplace.css:_
+_src/styles/marketplaceIndex.css:_
 
 ```css
 /* Google Maps needs 72px bottom padding to accommodate logo, Mapbox doesn't have one */

--- a/src/docs/ftw-styling/how-to-add-static-pages-in-ftw/index.md
+++ b/src/docs/ftw-styling/how-to-add-static-pages-in-ftw/index.md
@@ -25,7 +25,7 @@ like `src/containers/AboutPage/AboutPage.js`.
 ## 3. Create a CSS file
 
 Create a new CSS file using the folder name. The path should look like
-`src/containers/AboutPage/AboutPage.css`.
+`src/containers/AboutPage/AboutPage.module.css`.
 
 ## 4. Create the component
 
@@ -45,7 +45,7 @@ import {
   ExternalLink,
 } from '../../components';
 
-import css from './AboutPage.css';
+import css from './AboutPage.module.css';
 import image from './path/to/image.png';
 
 const AboutPage = () => {
@@ -138,7 +138,7 @@ folder. With CSS we are using
 possible clashes of different class names.
 
 ```jsx
-import css from './AboutPage.css';
+import css from './AboutPage.module.css';
 ```
 
 Then we also import an image which is used later
@@ -209,15 +209,13 @@ And as a final step we need to export the component.
 
 ## 5. Add some styles to the CSS file
 
-Here's an example what your AboutPage.css file could look like:
+Here's an example what your AboutPage.module.css file could look like:
 
 ```css
-@import '../../marketplace.css';
-
 .root {
   padding: 24px;
 
-  /* Use CSS variable imported from marketplace.css */
+  /* Use CSS variable defined in src/styles/marketplaceDefaults.css */
   background-color: var(--marketplaceColor);
 }
 ```

--- a/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
+++ b/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
@@ -1,7 +1,7 @@
 ---
 title: How to customize FTW styles
 slug: how-to-customize-ftw-styles
-updated: 2019-01-28
+updated: 2020-11-17
 category: ftw-styling
 ingress:
   This guide describes how to change the styles of the Flex Template for
@@ -16,44 +16,42 @@ along with globally defined cascading behavior that CSS is all about.
 To tackle this goal, we have split the styling into two levels in this
 template application:
 
-- [Marketplace level styling](#marketplace-level-styling) through
-  _marketplace.css_ (a kind of global theme)
+- [Marketplace level styling](#marketplace-level-styling) with 2 global
+  stylesheets:
+  - _src/styles/marketplaceDefaults.css_ (contains CSS variables and
+    element styles)
+  - _src/styles/propertySets.css_ (contains CSS Property Sets aka @apply
+    rules)
 - [Component level styling](#styling-components) using
   [CSS Modules](https://github.com/css-modules/css-modules)
 
 ## Marketplace level styling
 
-On top of functionalities provided by Create React App, we have
-[added a couple of extra libraries](https://www.npmjs.com/package/sharetribe-scripts#differences-to-react-scripts)
-to help to design consistent UIs faster. CSS Properties and CSS Property
-Sets are very useful for all kind of style sharing purposes, and we have
-created marketplace-level styling variables with them.
+We have created marketplace-level styling variables with CSS Properties
+(vars) and CSS Property Sets (@apply rules).
 
 The concept behind CSS Properties is quite straightforward - they are
-variables that can be defined in root-element level and then used inside
-some CSS rule.
+variables that can be defined in root-element level (`<html>`) and then
+used inside some CSS rule.
 
 ```css
+/* in src/styles/marketplaceDefaults.css */
 :root {
   --marketplaceColor: #ffff00;
 }
+```
 
+```css
+/* in component.module.css */
 .linkToHomePage {
   color: var(--marketplaceColor);
 }
 ```
 
 (Read more about CSS Properties from
-[cssnext](https://cssnext.github.io/))
+[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties))
 
-We have used this concept to create a marketplace-level "theming" that's
-defined in three files:
-[src/marketplace.css](https://github.com/sharetribe/flex-template-web/blob/master/src/marketplace.css),
-[src/marketplaceFonts.css](https://github.com/sharetribe/flex-template-web/blob/master/src/marketplaceFonts.css),
-and
-[src/marketplaceIndex.css](https://github.com/sharetribe/flex-template-web/blob/master/src/marketplaceIndex.css).
-
-### `src/marketplace.css`
+### `src/styles/marketplaceDefaults.css`
 
 This is a good place to start customizing marketplace styles. For
 example, we define our color scheme here using CSS Property variables:
@@ -116,7 +114,10 @@ Breakpoints for media queries are also defined in this file:
 @custom-media --viewportXLarge (min-width: 1921px);
 ```
 
-### `src/marketplaceFonts.css`
+In addition, this file provides default styles for plain elements like
+`<body>`, `<a>`, `<p>`, `<input>`, `<h1>`, `<h2>`, and so on.
+
+### `src/styles/propertySets.css`
 
 Fonts are specified in this files using CSS Property Sets. They provide
 us a solid way of creating a fixed set of CSS rules for a specific font.
@@ -124,8 +125,6 @@ us a solid way of creating a fixed set of CSS rules for a specific font.
 For example, our default font is defined as:
 
 ```css
---fontWeightMedium: 500;
-
 --marketplaceDefaultFontStyles: {
   font-family: 'sofiapro', Helvetica, Arial, sans-serif;
   font-weight: var(--fontWeightMedium);
@@ -148,10 +147,6 @@ p {
 }
 ```
 
-_marketplaceFonts.css_ are included to _marketplace.css_, so you don't
-need to import this file on new components (importing _marketplace.css_
-is enough).
-
 ⚠️ NOTE: template app is following a pattern where the height of an
 element should be divisible by `6px` on mobile layout and `8px` on
 bigger layouts. This affects line-heights of font styles too.
@@ -161,11 +156,6 @@ get any more support from browser vendors as the spec is yet considered
 deprecated and alternative solutions are being discussed. However,
 template app will use these until a good enough alternative is
 available.
-
-### `src/marketplaceIndex.css`
-
-This file provides default styles for plain elements like `<body>`,
-`<a>`, `<p>`, `<input>`, `<h1>`, `<h2>`, and so on.
 
 ## Styling components
 
@@ -182,13 +172,13 @@ achieve this, we have used
 the syntax close to plain CSS, but it actually creates unique class
 names to remove the problems caused by the global nature of CSS. In
 practice, this means that a class with name `card` is actually renamed
-as `ComponentName__card__3kj4h5`.
+as `ComponentName_card__3kj4h5`.
 
-To use styles defined in SectionHero.css, we need to import the .css
+To use styles defined in SectionHero.module.css, we need to import the
 file into the component:
 
 ```jsx
-import css from './SectionHero.css';
+import css from './SectionHero.module.css';
 ```
 
 and then select the correct class from imported style object (in this
@@ -210,18 +200,18 @@ from the context menu.)
 ![Mobile LandingPage hero title](./styling-find-component.png)
 
 Here we have opened title on LandingPage and the styles for
-`<h1 class="SectionHero__heroMainTitle__3mVNg"><span>Book saunas everywhere.</span></h1>`
-are defined in a "class" called `SectionHero__heroMainTitle__3mVNg`. As
+`<h1 class="SectionHero_heroMainTitle__3mVNg"><span>Book saunas everywhere.</span></h1>`
+are defined in a "class" called `SectionHero_heroMainTitle__3mVNg`. As
 stated before, the first part of a class name is actually giving us a
 hint about what component is defining that style - in this case, it's
 _SectionHero_ and its styles can be found from the file:
-`src/components/SectionHero/SectionHero.css`.
+`src/components/SectionHero/SectionHero.module.css`.
 
 There's only two groups of components that break that rule:
 
-- _src/containers_ (These components are connected to Redux store: Pages
-  and TopbarContainer)
-- _src/forms_
+- **src/containers** (These components are connected to Redux store:
+  Pages and TopbarContainer)
+- **src/forms**
 
 ### Styling guidelines and good practices
 
@@ -235,27 +225,27 @@ structure needed, additional classes are named semantically.
 
 Some guidelines we have tried to follow:
 
-- **Use semantic class names** (They improve readability and decouples
-  style changes from DOM changes.)
-- **Use CSS Properties defined in marketplace.css** and create new ones
-  when it makes sense.
-- **Use classes**, don't style DOM elements directly. (Element styles
-  are global even with CSS Modules.)
-- **Avoid nesting styles**. (CSS Modules makes specificity rules
-  unnecessary.)
+- **Use semantic class names**<br/> They improve readability and
+  decouples style changes from DOM changes.
+- **Use CSS Properties defined in marketplaceDefaults.css**<br/> and
+  create new ones when it makes sense.
+- **Use classes**, don't style DOM elements directly.<br/> Element
+  styles are global even with CSS Modules.
+- **Avoid nesting styles**.<br/> CSS Modules makes specificity rules
+  unnecessary.
 - **Group and comment style rules** inside declaration block if that
   improves readability.
 - **Parent component is responsible for allocating space** for a child
   component (i.e. dimensions and margins).
-- **Define `@apply` rules early enough** inside declaration block (since
-  rules inside those property sets might overwrite rules written above
-  the line where the set is applied).
+- **Define `@apply` rules early enough** inside declaration block.<br/>
+  Rules inside those property sets might overwrite rules written above
+  the line where the set is applied.
 - **Align text and components** to horizontal baselines. I.e. they
   should be a multiple of `6px` on mobile layout and `8px` on bigger
   screens.
-- **Component height should follow baselines too**. I.e. they should be
-  a multiple of `6px` on mobile layout and `8px` on bigger screens.
-  _(Unfortunately, we haven't been strict with this one.)_
+- **Component height should follow baselines too**.<br/> I.e. they
+  should be a multiple of `6px` on mobile layout and `8px` on bigger
+  screens. _(Unfortunately, we haven't been strict with this one.)_
 
 ### Styling responsibility: parent component and its children
 
@@ -279,8 +269,15 @@ Style definitions of the (`<Circle />`) child component:
 }
 ```
 
-Parent component renders
-(`<div className={css.root}><Circle className={css.circleDimensions} /></div>`):
+Parent component could render something like:
+
+```jsx
+<div className={css.root}>
+  <Circle className={css.circleDimensions} />
+</div>
+```
+
+and it uses classes:
 
 ```css
 .root {
@@ -317,9 +314,45 @@ generated in an import order, therefore we want to avoid situations
 where `<Component className="classA classB"/>` could end up overwriting
 each others depending on the order they are imported.)
 
+```jsx
+import React from 'react';
+import css from './MyComponent.module.css';
+
+export const MyComponent = props => {
+  const { className, rootClassName } = props;
+  const classes = classNames(rootClassName || css.root, className);
+  return <div className={classes}>Hello World</div>;
+};
+```
+
 In some complex cases, we have also created props for overwriting some
 inner classes of child components. In these cases, child component is
 also replacing its own styling class with the class passed-in through
 props. For example, `<LocationAutocompleteInput>` can take a prop called
 `iconClassName`, which (if given) replaces `.icon` class defined inside
-`LocationAutocompleteInput.css`.
+`LocationAutocompleteInput.module.css`.
+
+## Using vanilla CSS
+
+FTW templates don't use vanilla CSS, but it is possible to take vanilla
+CSS into use just by creating CSS file that doesn't use `*.module.css`
+pattern in its file name.
+
+Read more about using vanilla CSS from Create React App's docs:<br/>
+https://create-react-app.dev/docs/adding-a-stylesheet
+
+<extrainfo title="Before FTW-daily@v7.0.0 or FTW-hourly@v9.0.0">
+
+Old template version before FTW-daily@v7.0.0 or FTW-hourly@v9.0.0 are
+expecting all `*.css` files to contain CSS Modules markup. Adding
+vanilla CSS in those setups required that the file was uploaded outside
+of the build process.
+
+In practice, the files using plain CSS could be added to
+_public/static/_ directory and then linked them inside _index.html_:
+
+```html
+<link rel="stylesheet" href="%PUBLIC_URL%/static/myStylesheet.css" />
+```
+
+</extrainfo>

--- a/src/docs/introduction/getting-started-with-ftw-daily/index.md
+++ b/src/docs/introduction/getting-started-with-ftw-daily/index.md
@@ -75,6 +75,10 @@ basic development tooling:
    │   ├── config.js
    │   └── translations.js
    ├── server
+   │   ├── api
+   │   ├── api-util
+   │   ├── apiRouter.js
+   │   ├── apiServer.js
    │   ├── auth.js
    │   ├── csp.js
    │   ├── dataLoader.js
@@ -91,6 +95,9 @@ basic development tooling:
    │   ├── containers
    │   ├── ducks
    │   ├── forms
+   │   ├── styles
+   │   │   ├── marketplaceDefaults.css
+   │   │   └── propertySets.css
    │   ├── translations
    │   ├── util
    │   ├── Routes.js
@@ -101,9 +108,6 @@ basic development tooling:
    │   ├── examples.js
    │   ├── index.js
    │   ├── marketplace-custom-config.js
-   │   ├── marketplace.css
-   │   ├── marketplaceFonts.css
-   │   ├── marketplaceIndex.css
    │   ├── reducers.js
    │   ├── routeConfiguration.js
    │   ├── store.js

--- a/src/docs/tutorial-branding/add-faq-page/index.md
+++ b/src/docs/tutorial-branding/add-faq-page/index.md
@@ -177,7 +177,7 @@ import {
   Footer,
 } from '../../components';
 
-import css from './FAQPage.css';
+import css from './FAQPage.module.css';
 
 const FAQPage = () => {
   // prettier-ignore
@@ -220,12 +220,10 @@ component - so, it's imported from _components_ directory.
 
 The main content is added as a child to _LayoutWrapperMain_ component.
 
-In addition, we have imported "css" object from FAQPage.css file. You
-can create that file with the following content:
+In addition, we have imported "css" object from FAQPage.module.css file.
+You can create that file with the following content:
 
 ```css
-@import '../../marketplace.css';
-
 .mainWrapper {
   width: calc(100% - 48px);
   max-width: 720px;

--- a/src/docs/tutorial-branding/change-image-assets/index.md
+++ b/src/docs/tutorial-branding/change-image-assets/index.md
@@ -10,15 +10,16 @@ published: true
 ## Default background image
 
 In the [previous step](/tutorial-branding/first-edit/), you made changes
-to the marketplace.css file. You might have noticed that the there was
-**`--backgroundImage`** property set mentioned. That variable is used to
-provide a background image for Hero component on the landing page as
-well as some of the other pages: sing-up and log-in, email verification
-etc.
+to the marketplaceDefaults.css file. This time you make changes to
+propertySets.css. **`--backgroundImage`** variable can be found from
+there. It is used to provide a background image for Hero component on
+the landing page as well as some of the other pages: sing-up and log-in,
+email verification etc.
 
 ```shell
 └── src
-    └── marketplace.css
+    └── styles
+        └── propertySets.css
 ```
 
 ```css

--- a/src/docs/tutorial-branding/change-logo/index.md
+++ b/src/docs/tutorial-branding/change-logo/index.md
@@ -24,7 +24,7 @@ directory:
     ├── components
     │   └── Logo
     │       ├── IconLogo.js
-    │       ├── Logo.css
+    │       ├── Logo.module.css
     │       ├── Logo.js
     │       └── saunatime-logo.png
     ├── containers
@@ -111,7 +111,7 @@ import classNames from 'classnames';
 import config from '../../config';
 import MobileLogoImage from './cottagedays-logo-small.png';
 import DesktopLogoImage from './cottagedays-logo.png';
-import css from './Logo.css';
+import css from './Logo.module.css';
 
 const Logo = props => {
   const { className, format, ...rest } = props;

--- a/src/docs/tutorial-branding/first-edit/index.md
+++ b/src/docs/tutorial-branding/first-edit/index.md
@@ -18,15 +18,15 @@ property sets:
 
 ```shell
 └── src
-    ├── marketplace.css
-    ├── marketplaceFonts.css
-    └── marketplaceIndex.css
+    └── styles
+        ├── propertySets.css
+        └── marketplaceDefaults.css
 ```
 
 ## Changing CSS variables
 
-The most important file is **marketplace.css**, where you can find CSS
-variable `--marketplaceColor` and its two variants.
+The most important file is **marketplaceDefaults.css**, where you can
+find CSS variable `--marketplaceColor` and its two variants.
 
 ```css
 /* ================ Colors ================ */

--- a/src/docs/tutorial-extended-data/show-extended-data/index.md
+++ b/src/docs/tutorial-extended-data/show-extended-data/index.md
@@ -33,7 +33,7 @@ import React from 'react';
 import { FormattedMessage } from '../../util/reactIntl';
 
 // Import css from existing CSS Modules file:
-import css from './ListingPage.css';
+import css from './ListingPage.module.css';
 
 // Create new React component
 const SectionViewMaybe = props => {

--- a/src/docs/tutorial-transaction-process/customize-pricing/index.md
+++ b/src/docs/tutorial-transaction-process/customize-pricing/index.md
@@ -222,7 +222,7 @@ checkbox component _FieldCheckbox_.
 } from '../../components';
  import EstimatedBreakdownMaybe from './EstimatedBreakdownMaybe';
 
- import css from './BookingDatesForm.css';
+ import css from './BookingDatesForm.module.css';
 + const { Money } = sdkTypes;
 ```
 

--- a/src/docs/tutorial-transaction-process/use-protected-data-in-emails/index.md
+++ b/src/docs/tutorial-transaction-process/use-protected-data-in-emails/index.md
@@ -34,7 +34,7 @@ field to collect phone numbers. It's called **FieldPhoneNumberInput**.
     └── forms
         └── SignupForm
             ├── SignupForm.js
-            └── SignupForm.css
+            └── SignupForm.module.css
 ```
 
 We need to **_import_** _FieldPhoneNumberInput_ component and then add
@@ -74,7 +74,7 @@ const phoneRequired = validators.required(phoneRequiredMessage);
 > validator just checks that the input is not empty.
 
 We also need to add style-rules for **css.phone**. You can add the
-following style-rules to _SignupForm.css_:
+following style-rules to _SignupForm.module.css_:
 
 ```css
 .phone {


### PR DESCRIPTION
- Renamed component stylesheets: `*.css` => `*.module.css`
- Removed **marketplaceIndex.css**
- Removed **marketplaceFonts.css**
- Removed **marketplace.css**
- New **src/styles/marketplaceDefaults.css**
- New **src/styles/propertySets.css**
- How to use vanilla CSS