### PR TITLE
Update articles: How routing works & code splitting & first edit

### DIFF
--- a/src/docs/ftw-routing/how-code-splitting-works-in-ftw/index.md
+++ b/src/docs/ftw-routing/how-code-splitting-works-in-ftw/index.md
@@ -1,0 +1,219 @@
+---
+title: How code splitting works in FTW
+slug: how-code-splitting-works-in-ftw
+updated: 2021-02-12
+category: ftw-routing
+ingress:
+  This article explains how the code splitting setup works in Flex
+  Template for Web (FTW).
+published: true
+---
+
+Previously, _sharetribe-scripts_ created one
+[UMD](https://dev.to/iggredible/what-the-heck-are-cjs-amd-umd-and-esm-ikm)
+build that was used on both server and frontend. I.e. all the code used
+in the app was bundled into a single main.bundle.js file and that was
+used in the web app and server.
+
+Unfortunately, this has meant that code-splitting was not supported: it
+didn't work with the UMD build due to an old bug in Webpack.
+
+With sharetribe-scripts version _5.0.0_, we changed this behaviour:
+sharetribe-scripts creates 2 different builds when `yarn run build` is
+called. Basically, this means that build-time increases (including
+`yarn run dev-server` call).
+
+However, this setup makes code-splitting possible. To make this easier,
+we have added [Loadable Components](https://loadable-components.com/)
+library to the setup.
+
+> **Note:** FTW-daily started using code-splitting from version _8.0.0_
+> and FTW-hourly from _10.0.0_.
+
+## What is code splitting
+
+Instead of downloading the entire app before users can use it, code
+splitting allows us to split the code from one main.bundle.js file into
+smaller chunks which you can then load on demand. To familiarize
+yourself with the subject, you could read about code splitting from
+[reactjs.org](https://reactjs.org/docs/code-splitting.html).
+
+In practice, FTW templates use route-based code splitting: page-level
+components are now using
+[Loadable Components](https://loadable-components.com/) syntax to create
+[dynamic imports](https://webpack.js.org/api/module-methods/#import-1)
+functionality.
+
+```js
+const AboutPage = loadable(() =>
+  import(
+    /* webpackChunkName: "AboutPage" */ './containers/AboutPage/AboutPage'
+  )
+);
+```
+
+When Webpack comes across these loadable objects, it will create a new
+JS & CSS chunk files (e.g. _AboutPage.dc3102d3.chunk.js_). I.e. those
+code-paths are separated from the main bundle.
+
+Previously, (when code-splitting was not supported), when you loaded
+`/about` page, you received _main.bundle.js_ & _main.bundle.css_. Those
+files were pretty huge containing all the code that was needed to create
+a template app and any page inside it. Loading a single file takes time
+and also browsers had to evaluate the entire JS-file before it was ready
+to make the app fully functional.
+
+So, the main benefit of code splitting is to reduce the code that is
+loaded for any single page. That improves the performance, but even more
+importantly, it makes it possible to add more navigational paths and
+page-variants to the codebase. For example, adding different kinds of
+ListingPages for different types of listings makes more sense with
+code-splitting. Otherwise, new pages would have a performance impact on
+the initial page load and therefore SEO performance would drop too.
+
+> Note: currently, most of the code is in shared _src/components/_
+> directory and this reduces the benefits that come from code-splitting.
+> In the future, we are probably going to move some components from
+> there to page-specific directories (if they are not truly shared
+> between different pages).
+
+## How code splitting works in practice
+
+If you open `/about` page, you'll notice that there are several JS & CSS
+files loaded:
+
+- **Main chunk** (e.g. _main.1df6bb19.chunk.js_ &
+  main.af610ce4.chunk.css). They contain code that is shared between
+  different pages.
+- [**Vendor chunk**](https://twitter.com/wSokra/status/969633336732905474)
+  (Currently, it's an unnamed chunk file. e.g. _24.230845cc.chunk.js_)
+- **Page-specific chunk** (e.g. _AboutPage.dc3102d3.chunk.js_)
+- **Runtime chunk** (e.g. _runtime-main.818a6866.js_) This one takes
+  care of loading correct JS & CSS files when you navigate to another
+  page inside the web app. (e.g. it loads
+  _LandingPage.6fa732d5.chunk.js_ && _LandingPage.40c0bf91.chunk.css_,
+  when a user navigates to the landing page.)
+
+So, there are several chunk files that can be loaded parallel in the
+first page-load and also page-specific chunks that can be loaded in
+response to in-app navigation.
+
+Naturally, this means that during in-app navigation there are now more
+things that the app needs to load: **data** that the next page needs and
+**code chunk** that it needs to render the data. The latter is not
+needed if the page-specific chunk is already loaded earlier.
+
+## Preloading code chunks
+
+Route-based code splitting means that there might be a fast flickering
+of a blank page when navigation happens for the first time to a new
+page. To remedy that situation, FTW templates have forced the
+page-chunks to be
+[preloaded](https://loadable-components.com/docs/prefetching/#manually-preload-a-component)
+when the mouse is over **NamedLink**. In addition, **Form** and
+**Button** components can have a property
+`enforcePagePreloadFor="SearchPage"`. That way the specified chunk is
+loaded before the user has actually clicked the button or executed form
+submit.
+
+## Route configuration
+
+To make the aforementioned preloading possible, the loadable component
+is directly set to "component" conf in routeConfigurations.js file:
+
+```shell
+└── src
+    └── routeConfiguration.js
+```
+
+```js
+    // const AuthenticationPage = loadable(() => import(/* webpackChunkName: "AuthenticationPage" */ './containers/AuthenticationPage/AuthenticationPage'));
+    {
+      path: '/signup',
+      name: 'SignupPage',
+      component: AuthenticationPage,
+      extraProps: { tab: 'signup' },
+    },
+```
+
+### Data loading
+
+FTW templates collects _loadData_ and _setInitialValues_ Redux functions
+from
+[modular Redux file](https://github.com/erikras/ducks-modular-redux)
+(i.e. files that look like `<SomePageComponent>`.duck.js). This happens
+in _pageDataLoadingAPI.js_:
+
+```shell
+└── src
+    └── containers
+        └── pageDataLoadingAPI.js
+```
+
+Then those files can be connected with routing through route
+configuration.
+
+```js
+    // import pageDataLoadingAPI from './containers/pageDataLoadingAPI';
+    {
+      path: '/l/:slug/:id',
+      name: 'ListingPage',
+      component: ListingPage,
+      loadData: pageDataLoadingAPI.ListingPage.loadData,
+    },
+```
+
+## CSS chunk changes
+
+To ensure that every page-level CSS chunk has custom media queries
+included, those breakpoints are included through a separate file
+(_customMediaQueries.css_) and it is imported into the main stylesheet
+of every page.
+
+```shell
+└── src
+    └── styles
+        └── customMediaQueries.css
+```
+
+## Server-side rendering (SSR)
+
+When FTW templates receive a page-load call on server and the page is a
+public one (_"auth"_ flag is not set in route configuration), the server
+will render the page into a string and returns it among HTML code. This
+process has 4 main steps:
+
+1. _server/dataLoader.js_ initializes store
+2. It also figures out which route is used and fetches route
+   configuration for it
+3. If the configuration contains a _loadData_ function, the call is
+   dispatched
+4. As a consequence, the store gets populated and it can be used to
+   render the app to a string.
+
+### Build directory
+
+Sharetribe-scripts dependency uses Webpack to build the application. It
+copies the content from _public/_ directory into the _build_ directory
+and the Webpack build bundles all the code into files that can be used
+in production mode.
+
+- Code for server-side rendering is saved to _build/node_ directory.
+- Code for client-side rendering is saved to _build/static_ directory.
+- Both builds have also a _loadable-stats.json_ file, which basically
+  tells what assets different pages need.
+- _server/importer.js_ exposes two
+  [ChunkExtractors](https://loadable-components.com/docs/server-side-rendering/#collecting-chunks) -
+  one for web and another for node build.
+- _server/index.js_ requires the entrypoint for the node build, extracts
+  relevant info, and passes them to _dataLoader.loadData()_ and
+  _rendered.render()_ calls.
+- webExtractor (ChunkExtractor for the web build) is used to collect
+  those different code chunks (JS & CSS files) that the current
+  page-load is going to need.
+
+  > In practice, **renderApp** function wraps the app with
+  > _webExtractor.collectChunks_. With that the webExtractor can figure
+  > out all the relevant loadable calls that the server uses for the
+  > current page and therefore the web-versions of those chunks can be
+  > included to rendered pages through `<script>` tags.

--- a/src/docs/ftw-routing/how-routing-works-in-ftw/index.md
+++ b/src/docs/ftw-routing/how-routing-works-in-ftw/index.md
@@ -1,7 +1,7 @@
 ---
 title: How routing works in FTW
 slug: how-routing-works-in-ftw
-updated: 2019-01-29
+updated: 2021-02-12
 category: ftw-routing
 ingress:
   This article explains how the routing setup works in Flex Template for
@@ -11,11 +11,11 @@ published: true
 
 FTW uses [React Router](https://reacttraining.com/react-router/web) for
 creating routes to different pages. React Router is a collection of
-navigational components that allow single page apps to create routing as
-a part of normal rendering flow of the React app. So, instead of
-defining on server-side what gets rendered when user goes to URL
-`somemarketplace.com/about`, we just catch all the path combinations and
-let the app to define what page gets rendered.
+navigational components that allow single-page apps to create routing as
+a part of the normal rendering flow of the React app. So, instead of
+defining on the server what gets rendered when a user goes to URL
+_"somemarketplace.com/about"_, we just catch all the path combinations
+and let the app define what page gets rendered.
 
 ## React Router setup
 
@@ -23,17 +23,25 @@ let the app to define what page gets rendered.
 
 FTW has a quite straightforward routing setup - there's just one file
 you need to check before you link to existing routes or start creating
-new routes to static pages: `src/routeConfiguration.js`.
+new routes to static pages: _src/routeConfiguration.js_.
 
-There we have imported and configured all the page-level components that
-are currently used within FTW:
+There we have imported all the page-level components dynamically using
+[Loadable Components](https://loadable-components.com/). In addition,
+there's a configuration that specifies all the pages that are currently
+used within FTW:
 
-```jsx
-import {
-  AboutPage,
-  AuthenticationPage,
-  //...
-} from './containers';
+```js
+const AboutPage = loadable(() =>
+  import(
+    /* webpackChunkName: "AboutPage" */ './containers/AboutPage/AboutPage'
+  )
+);
+const AuthenticationPage = loadable(() =>
+  import(
+    /* webpackChunkName: "AuthenticationPage" */ './containers/AuthenticationPage/AuthenticationPage'
+  )
+);
+// etc..
 
 // Our routes are exact by default.
 // See behaviour from Routes.js where Route is created.
@@ -47,14 +55,14 @@ const routeConfiguration = () => {
     {
       path: '/login',
       name: 'LoginPage',
-      component: props => <AuthenticationPage {...props} tab="login" />,
+      component: AuthenticationPage,
+      extraProps: { tab: 'login' },
     },
     {
       path: '/signup',
       name: 'SignupPage',
-      component: props => (
-        <AuthenticationPage {...props} tab="signup" />
-      ),
+      component: AuthenticationPage,
+      extraProps: { tab: 'signup' },
     },
     //...
   ];
@@ -63,66 +71,70 @@ const routeConfiguration = () => {
 export default routeConfiguration;
 ```
 
-In the example, path `/login` renders `AuthenticationPage` component
-with prop 'tab' set to 'login'. In addition, this route configuration
-has a name 'LoginPage'.
+In the example, path `/login` renders _AuthenticationPage_ component
+with prop **tab** set to 'login'. In addition, this route configuration
+has the name: 'LoginPage'.
 
 > Routes use exact path matches in FTW. We felt that this makes it
 > easier to understand the connection between a path and its routed view
 > aka related page component.
-> [Read more.](https://reacttraining.com/react-router/web/api/Route/exact-bool)
+> [Read more.](https://reactrouter.com/web/api/Route/exact-bool)
 
 There are a couple of extra configurations you can set. For example
 `/listings` path leads to a page that lists all the listings provided by
 the current user:
 
-```jsx
+```js
 {
   path: '/listings',
   name: 'ManageListingsPage',
   auth: true,
-  authPage: 'LoginPage', // default is 'SingupPage'
-  component: props => <ManageListingsPage {...props} />,
-  loadData: ManageListingsPage.loadData,
+  authPage: 'LoginPage', // the default is 'SingupPage'
+  component: ManageListingsPage,
+  loadData: pageDataLoadingAPI.ManageListingsPage.loadData,
 },
 ```
 
-Here we have set this route to be available only for authenticated user
-(`auth: true`), because we need to know whose listings we should fetch.
-If a user is unauthenticated, he/she is redirected to LoginPage
-(`authPage: 'LoginPage'`) before he/she can see the content of
-`ManageListingsPage` page.
+Here we have set this route to be available only for the authenticated
+users (`auth: true`) because we need to know whose listings we should
+fetch. If a user is unauthenticated, he/she is redirected to LoginPage
+(`authPage: 'LoginPage'`) before the user can see the content of the
+_"ManageListingsPage"_ route.
 
-There's also a `loadData` function defined. It is a special function
+There's also a _loadData_ function defined. It is a special function
 that gets called if a page needs to fetch more data (e.g. from the
 Marketplace API) after redirecting to that route. We'll open up this
 concept in the [Loading data](#loading-data) section below.
 
 In addition to these configurations, there's also a rarely used
-`setInitialValues` function that could be defined and passed to a route:
+_setInitialValues_ function that could be defined and passed to a route:
 
-```jsx
+```js
 {
   path: '/l/:slug/:id/checkout',
   name: 'CheckoutPage',
   auth: true,
-  component: props => <CheckoutPage {...props} />,
-  setInitialValues: CheckoutPage.setInitialValues,
+  component: CheckoutPage,
+  setInitialValues: pageDataLoadingAPI.CheckoutPage.setInitialValues,
 },
 ```
 
 This function gets called when some page wants to pass forward some
-extra data before redirecting user to that page. For example we could
+extra data before redirecting a user to that page. For example, we could
 ask booking dates on ListingPage and initialize CheckoutPage state with
-that data before buyer is redirected to CheckoutPage.
+that data before a customer is redirected to CheckoutPage.
 
-### How FTW renders a router with routeConfiguration.js
+Both _loadData_ and _setInitialValues_ functions are part of Redux data
+flow. They are defined in page-specific SomePage.duck.js files and
+exported through _src/containers/pageDataLoadingAPI.js_.
 
-Aforementioned route configuration is used in `src/app.js`. For example,
-`ClientApp` defines `BrowserRouter` and gives it a child component
-(`Routes`) that gets the configuration as `routes` property.
+### How FTW renders a route with routeConfiguration.js
 
-Simplified `app.js` code that renders client-side FTW app:
+The route configuration is used in _src/app.js_. For example,
+**ClientApp** defines **BrowserRouter** and gives it a child component
+(**Routes**) that gets the configuration as _routes_ property.
+
+Here's a simplified _app.js_ code that renders client-side FTW app:
 
 ```jsx
 import { BrowserRouter } from 'react-router-dom';
@@ -138,8 +150,9 @@ export const ClientApp = props => {
 };
 ```
 
-`src/Routes.js` renders the `Route` navigational components (`Switch`
-renders the first `Route` that matches the location):
+_src/Routes.js_ renders the navigational **Route** components.
+**Switch** component renders the first _Route_ that matches the
+location.
 
 ```jsx
 import { Switch, Route } from 'react-router-dom';
@@ -155,26 +168,31 @@ const Routes = (props, context) => {
   );
 ```
 
-Inside `src/Routes.js`, we also have a component called
-`RouteComponentRenderer`, which has three important jobs:
+Inside _src/Routes.js_, we also have a component called
+_RouteComponentRenderer_, which has four important jobs:
 
 - Calling loadData function, if those have been defined in
-  `src/routeConfiguration.js`. This is an asynchronous call, a page
+  _src/routeConfiguration.js_. This is an asynchronous call, a page
   needs to define what gets rendered before data is complete.
 - Reset scroll position after location change.
 - Dispatch location changed actions to Redux store. This makes it
-  possible for analytics Redux middleware to listen location changes.
+  possible for analytics Redux middleware to listen to location changes.
   For more information, see the
   [How to set up Analytics for FTW](/ftw-analytics/how-to-set-up-analytics-for-ftw/)
   guide.
+- Rendering of the page-level component that the Route is connected
+  through the configuration. Those page-level components are Loadable
+  Components. When a page is rendered for the first time, the code-chunk
+  for that page needs to be fetched first.
 
 ## Linking
 
 Linking is a special case in SPA. Using HTML `<a>` tags will cause
-browser to redirect to given `href` location. That will cause all the
-resources to be fetched again, which is a slow and unnecessary step for
-SPA. Instead, we just need to tell our router to render a different page
-by adding or modifying browser's history entries.
+browser to redirect to given **"href"** location. That will cause all
+the resources to be fetched again, which is a slow and unnecessary step
+for SPA. Instead, we just need to tell our router to render a different
+page by adding or modifying the location through the browser's history
+API.
 
 ### NamedLink and NamedRedirect
 
@@ -183,19 +201,19 @@ React Router exports a couple of
 (e.g. `<Link to="/about">About</Link>`) that could be used for linking
 to different internal paths. Since FTW is a template app, we want all
 the paths to be customizable too. That means that we can't use paths
-directly when redirecting user to another Route. For example marketplace
-for German customer might want to customize the LoginPage path to be
-`/anmelden` instead of `/login` - and that would mean that all the
-_Links_ to it would need to be updated.
+directly when redirecting a user to another Route. For example, a
+marketplace for German customers might want to customize the LoginPage
+path to be `/anmelden` instead of `/login` - and that would mean that
+all the _Links_ to it would need to be updated.
 
-This is the reason why we have created names to different routes in
-`src/routeConfiguration.js`. We have a component called
+This is the reason why we have created names for different routes in
+_src/routeConfiguration.js_. We have a component called
 `<NamedLink name="LoginPage" />` and its _name_ property creates a link
-to the correct Route even if the path is changed in routeConfiguration.
-Needless to say that those names should only be used for internal route
-mapping.
+to the correct Route even if the path is changed in
+routeConfiguration.js. Needless to say that those names should only be
+used for internal route mapping.
 
-More complex example of `NamedLink`
+More complex example of _NamedLink_
 
 ```jsx
 // Link to LoginPage:
@@ -208,11 +226,11 @@ More complex example of `NamedLink`
 <NamedLink name="SearchPage" to={{ search: '?bounds=60.53,22.38,60.33,22.06' }}>Turku city</NamedLink>
 ```
 
-`NamedLink` is widely used in FTW, but there are some cases when we have
-made redirection to another page if some data is missing (e.g.
+_NamedLink_ is widely used in FTW, but there are some cases when we have
+made a redirection to another page if some data is missing (e.g.
 CheckoutPage redirects to ListingPage, if some data is missing or it is
-old). This can be done with rendering component called `NamedRedirect`,
-which is a similar wrapper for
+old). This can be done by rendering a component called
+**NamedRedirect**, which is a similar wrapper for the
 [Redirect component](https://reacttraining.com/react-router/web/api/Redirect).
 
 ### ExternalLink
@@ -221,22 +239,27 @@ There's also a component for external links. The reason why it exists is
 that there's a
 [security issue](https://mathiasbynens.github.io/rel-noopener/) that can
 be exploited when a site is linking to external resources.
-`ExternalLink` component has some safety measures to prevent those. We
-recommend that all the external links are created using
-`ExternalLink`component instead of directly writing anchors like
-`<a href="externalsite.com">External site</a>`. (You can just change the
-JSX element accordinly:
-`<ExternalLink href="externalsite.com">External site</ExternalLink>`.)
+**ExternalLink** component has some safety measures to prevent those. We
+recommend that all the external links are created using _ExternalLink_
+component instead of directly writing `<a>` anchors.
+
+```jsx
+// Bad pattern: <a href="externalsite.com">External site</a>
+// Recommended pattern:
+<ExternalLink href="externalsite.com">External site</ExternalLink>
+```
 
 ## Loading data
 
 If a page component needs to fetch data, it can be done as a part of
-navigation. A page component needs to define a static function called
-`loadData`, which needs to return a Promise, which is resolved when all
+navigation. A page-level component has a related modular Redux file with
+a naming pattern: PageName.duck.js. To connect the data loading with
+navigation, there needs to be an exported function called _loadData_ in
+that file. That function returns a Promise, which is resolved when all
 the asynchronous Redux Thunk calls are completed.
 
-For example here's a bit simplified version of `ListingPage.loadData`
-function:
+For example, here's a bit simplified version of _loadData_ function on
+ListingPage:
 
 ```js
 export const loadData = (params, search) => dispatch => {
@@ -250,41 +273,73 @@ export const loadData = (params, search) => dispatch => {
 };
 ```
 
-> Unfortunately, `loadData` function needs to be separately mapped in
-> routeConfiguration.js atm. There has been a problem with module
-> initialization order and functional components have been used in
-> routeConfiguration.js as wrappers to prevent a premature call to these
-> static functions.
+Note: **loadData** function needs to be separately mapped in
+routeConfiguration.js and to do that those data loading functions are
+collected into pageDataLoadingAPI.js file.
+
+```shell
+└── src
+    └── containers
+        └── pageDataLoadingAPI.js
+```
+
+## Loading the code that renders a new page
+
+FTW templates use route-based code splitting. Different pages are split
+away from the main code bundle and those page-specific code chunks are
+loaded separately when the user navigates to a new page for the first
+time.
+
+This means that there might be a fast flickering of a blank page when
+navigation happens for the first time to a new page. To remedy that
+situation, FTW templates have forced the page-chunks to be
+[preloaded](https://loadable-components.com/docs/prefetching/#manually-preload-a-component)
+when the mouse is over **NamedLink**. In addition, **Form** and
+**Button** components can have a property
+`enforcePagePreloadFor="SearchPage"`. That way the specified chunk is
+loaded before the user has actually clicked the button or executed form
+submit.
+
+Read more about
+[code-splitting](/ftw-routing/how-code-splitting-works-in-ftw/).
 
 ## Analytics
 
 It is possible to track page views to gather information about
-navigation behaviour. Tracking is tied to routing through
-`src/Routes.js` where `RouteRendererComponent` dispatches
-`LOCATION_CHANGED` actions. These actions are handled by a global
-reducer (`src/ducks/Routing.duck.js`), but more importantly,
-`src/analytics/analytics.js` (a Redux middleware) listens to these
-changes and sends tracking events to configured services. For more
-information, see the
+navigation behaviour. Tracking is tied to routing through _Routes.js_
+where _RouteRendererComponent_ dispatches `LOCATION_CHANGED` actions.
+These actions are handled by a global reducer (_Routing.duck.js_), but
+more importantly, _analytics.js_ (a Redux middleware) listens to these
+changes and sends tracking events to configured services.
+
+```shell
+└── src
+    ├── Routes.js
+    ├──analytics
+    |  └── analytics.js
+    └── ducks
+        └── Routing.duck.js
+```
+
+For more information, see the
 [How to set up Analytics for FTW](/ftw-analytics/how-to-set-up-analytics-for-ftw/)
 guide.
 
 ## A brief introduction to SSR
 
-Server-side rendering needs a better documentation at some point, but
-this routing setup is the key to render any page on server-side without
-duplicating routing logic. We just need to fetch data if `loadData` is
-defined on page component and then use `ReactDOMServer.renderToString`
-to render the app to string (requested URL is a parameter for this
-render function).
+Routing configuration is one of the key files to render any page on the
+server without duplicating routing logic. We just need to fetch data if
+_loadData_ is defined on page component and then use
+`ReactDOMServer.renderToString` to render the app to string (requested
+URL is a parameter for this render function).
 
-So, instead of having something like this on Express server:
+So, instead of having something like this on the Express server:
 
 ```js
 app.get('/about', handleAbout);
 ```
 
-We basically catch every path call using `*` on `server/index.js`:
+We basically catch every path call using `*` on _server/index.js_:
 
 ```js
 app.get('*', (req, res) => {
@@ -300,11 +355,11 @@ and then we ask our React app to
 3.  send rendered HTML string as a response to the client browser
 
 ```js
-  dataLoader
-    .loadData(req.url, sdk)
-    .then(preloadedState => {
-      const html = renderer.render(req.url, context, preloadedState);
-      //...
-      res.send(html);
-    }
+dataLoader
+  .loadData(req.url, sdk /* other params */)
+  .then(preloadedState => {
+    const html = renderer.render(req.url /* and other params */);
+    //...
+    res.send(html);
+  });
 ```

--- a/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
+++ b/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
@@ -1,7 +1,7 @@
 ---
 title: How to customize FTW styles
 slug: how-to-customize-ftw-styles
-updated: 2020-11-17
+updated: 2021-02-12
 category: ftw-styling
 ingress:
   This guide describes how to change the styles of the Flex Template for
@@ -16,16 +16,26 @@ along with globally defined cascading behavior that CSS is all about.
 To tackle this goal, we have split the styling into two levels in this
 template application:
 
-- [Marketplace level styling](#marketplace-level-styling) with 2 global
+- [Marketplace level styling](#marketplace-level-styling) with 3 global
   stylesheets:
-  - _src/styles/marketplaceDefaults.css_ (contains CSS variables and
+  - _src/styles/**marketplaceDefaults.css**_ (contains CSS variables and
     element styles)
-  - _src/styles/propertySets.css_ (contains CSS Property Sets aka @apply
-    rules)
+  - _src/styles/**customMediaQueries.css**_ (contains breakpoints for
+    responsive layout)
+  - _src/styles/**propertySets.css**_ (contains CSS Property Sets aka
+    @apply rules)
 - [Component level styling](#styling-components) using
   [CSS Modules](https://github.com/css-modules/css-modules)
 
 ## Marketplace level styling
+
+```shell
+└── src
+    └── styles
+        ├── propertySets.css
+        ├── customMediaQueries.css
+        └── marketplaceDefaults.css
+```
 
 We have created marketplace-level styling variables with CSS Properties
 (vars) and CSS Property Sets (@apply rules).
@@ -51,7 +61,7 @@ used inside some CSS rule.
 (Read more about CSS Properties from
 [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties))
 
-### `src/styles/marketplaceDefaults.css`
+### marketplaceDefaults.css
 
 This is a good place to start customizing marketplace styles. For
 example, we define our color scheme here using CSS Property variables:
@@ -104,20 +114,39 @@ providing variables for box-shadows, border-radiuses, transitions, and
 so on. Our current plan is to parameterize styling even more using this
 concept.
 
-Breakpoints for media queries are also defined in this file:
-
-```css
-/* ================ Custom media queries ================ */
-
-@custom-media --viewportMedium (min-width: 768px);
-@custom-media --viewportLarge (min-width: 1024px);
-@custom-media --viewportXLarge (min-width: 1921px);
-```
-
 In addition, this file provides default styles for plain elements like
 `<body>`, `<a>`, `<p>`, `<input>`, `<h1>`, `<h2>`, and so on.
 
-### `src/styles/propertySets.css`
+### customMediaQueries.css
+
+Breakpoints for media queries are defined in separate file.
+
+```css
+@custom-media --viewportSmall (min-width: 550px);
+@custom-media --viewportMedium (min-width: 768px);
+@custom-media --viewportLarge (min-width: 1024px);
+// etc.
+```
+
+These custom media query breakpoints can be used in a similar way as CSS
+Properties. However, these variable are converted to real media queries
+on build-time.
+
+```css
+@media (--viewportMedium) {
+  /* CSS classes */
+}
+```
+
+On a live site, the CSS file contains:
+
+```css
+@media (min-width: 768px) {
+  /* CSS classes */
+}
+```
+
+### propertySets.css
 
 Fonts are specified in this files using CSS Property Sets. They provide
 us a solid way of creating a fixed set of CSS rules for a specific font.
@@ -147,23 +176,21 @@ p {
 }
 ```
 
-⚠️ NOTE: template app is following a pattern where the height of an
-element should be divisible by `6px` on mobile layout and `8px` on
-bigger layouts. This affects line-heights of font styles too.
+> ⚠️ **Note**: template app is following a pattern where the height of
+> an element should be divisible by **6px** on mobile layout and **8px**
+> on bigger layouts. This affects line-heights of font styles too.
 
-⚠️ NOTE: the `@apply` rule and custom property sets most likely won't
-get any more support from browser vendors as the spec is yet considered
-deprecated and alternative solutions are being discussed. However,
-template app will use these until a good enough alternative is
-available.
+> ⚠️ **Note**: the **@apply** rule and custom property sets most likely
+> won't get any more support from browser vendors as the spec is yet
+> considered deprecated and alternative solutions are being discussed.
 
 ## Styling components
 
 Styling a web UI is traditionally quite a messy business due to the
 global nature of stylesheets and especially their cascading specificity
 rule. `.card {/*...*/}` will affect every element on a web page that has
-a class `card` - even if the different UI context would like to use a
-different set of rules.
+a class **"card"** - even if the different UI context would like to use
+a different set of rules.
 
 Our goal has been to create independent components that can be reused in
 the UI without paying too much attention to the global CSS context. To
@@ -171,8 +198,8 @@ achieve this, we have used
 [CSS Modules](https://github.com/css-modules/css-modules), which keeps
 the syntax close to plain CSS, but it actually creates unique class
 names to remove the problems caused by the global nature of CSS. In
-practice, this means that a class with name `card` is actually renamed
-as `ComponentName_card__3kj4h5`.
+practice, this means that a class with name **card** is actually renamed
+as **_ComponentName_card\_\_3kj4h5_**.
 
 To use styles defined in SectionHero.module.css, we need to import the
 file into the component:
@@ -182,13 +209,13 @@ import css from './SectionHero.module.css';
 ```
 
 and then select the correct class from imported style object (in this
-case `heroMainTitle`):
+case **heroMainTitle**):
 
 ```jsx
 <h1 className={css.heroMainTitle}>Book saunas everywhere</h1>
 ```
 
-### Find the component to change its styles
+### Find the component
 
 Quite often one needs to find a component that is responsible for
 certain UI partial in order to change the styles. In this case, the
@@ -199,29 +226,46 @@ from the context menu.)
 
 ![Mobile LandingPage hero title](./styling-find-component.png)
 
-Here we have opened title on LandingPage and the styles for
-`<h1 class="SectionHero_heroMainTitle__3mVNg"><span>Book saunas everywhere.</span></h1>`
-are defined in a "class" called `SectionHero_heroMainTitle__3mVNg`. As
-stated before, the first part of a class name is actually giving us a
-hint about what component is defining that style - in this case, it's
-_SectionHero_ and its styles can be found from the file:
-`src/components/SectionHero/SectionHero.module.css`.
+Here we have opened title on LandingPage and the styles for the
+**heroMainTitle** heading:
+
+```html
+<h1 class="SectionHero_heroMainTitle__3mVNg">
+  <span>Book saunas everywhere.</span>
+</h1>
+```
+
+Styles are defined in a "class" called
+**`SectionHero_heroMainTitle__3mVNg`**. As stated before, the first part
+of a class name is actually giving us a hint about what component is
+defining that style - in this case, it's _SectionHero_ and its styles
+can be found from the file: **SectionHero.module.css**.
+
+```shell
+└── src
+    └── components
+        └── SectionHero
+            └── SectionHero.module.css
+```
 
 There's only two groups of components that break that rule:
 
-- **src/containers** (These components are connected to Redux store:
-  Pages and TopbarContainer)
+- **src/containers**
+
+  These components are connected to Redux store: Pages and
+  TopbarContainer
+
 - **src/forms**
 
-### Styling guidelines and good practices
+### Styling guidelines
 
 We have a practice of naming the outermost class of a component as
 `.root { /* styles */ }`. So, if the component is just rendering single
-element it only has `.root` class, and if there's more complex inner DOM
-structure needed, additional classes are named semantically.
+element it only has **.root** class, and if there's more complex inner
+DOM structure needed, additional classes are named semantically.
 
-`<SectionHero>` could contain classes named as `.root`,
-`.heroMainTitle`, `.heroSubtitle`.
+`<SectionHero>` could contain classes named as **.root**,
+**.heroMainTitle**, **.heroSubtitle**.
 
 Some guidelines we have tried to follow:
 
@@ -241,13 +285,14 @@ Some guidelines we have tried to follow:
   Rules inside those property sets might overwrite rules written above
   the line where the set is applied.
 - **Align text and components** to horizontal baselines. I.e. they
-  should be a multiple of `6px` on mobile layout and `8px` on bigger
-  screens.
+  should be a multiple of **_6px_** on mobile layout and **_8px_** on
+  bigger screens.
 - **Component height should follow baselines too**.<br/> I.e. they
-  should be a multiple of `6px` on mobile layout and `8px` on bigger
-  screens. _(Unfortunately, we haven't been strict with this one.)_
+  should be a multiple of **_6px_** on mobile layout and **_8px_** on
+  bigger screens. _(Unfortunately, we haven't been strict with this
+  one.)_
 
-### Styling responsibility: parent component and its children
+### Parent vs child
 
 One important aspect of a component-based UI is the fact that a
 component is usually only responsible for what happens inside its
@@ -256,9 +301,9 @@ parent component is responsible for its own layout and therefore it
 usually needs to be able to give some dimensions to its child components
 (and naturally margins between them).
 
-This creates a need for the parent to have means to pass `className` to
-its child as props. One example could be a component that shows a circle
-component inside itself and makes it 50px wide.
+This creates a need for the parent to have means to pass **className**
+to its child as props. One example could be a component that shows a
+circle component inside itself and makes it 50px wide.
 
 Style definitions of the (`<Circle />`) child component:
 
@@ -302,13 +347,13 @@ theme of child component there are generally two concepts available:
 
 - Create themed components (e.g. `<PrimaryButton>`, `<SecondaryButton>`,
   `<InlineButton>`)
-- Pass in a `class` property that is able to overwrite original styling
-  rules.
+- Pass in a **class** property that is able to overwrite original
+  styling rules.
 
 For the latter option, we have created a prop type concept called
-`rootClassName`. If you pass `rootClassName` through props to a
+**_rootClassName_**. If you pass **rootClassName** through props to a
 component, it will use that instead of component's own style rules
-defined in `.root`. This ensures that the order of style declarations
+defined in **.root**. This ensures that the order of style declarations
 inside final CSS bundle doesn't affect the final styles. (CSS bundle is
 generated in an import order, therefore we want to avoid situations
 where `<Component className="classA classB"/>` could end up overwriting
@@ -329,8 +374,8 @@ In some complex cases, we have also created props for overwriting some
 inner classes of child components. In these cases, child component is
 also replacing its own styling class with the class passed-in through
 props. For example, `<LocationAutocompleteInput>` can take a prop called
-`iconClassName`, which (if given) replaces `.icon` class defined inside
-`LocationAutocompleteInput.module.css`.
+**iconClassName**, which (if given) replaces **.icon** class defined
+inside _LocationAutocompleteInput.module.css_.
 
 ## Using vanilla CSS
 

--- a/src/docs/tutorial-branding/change-logo/index.md
+++ b/src/docs/tutorial-branding/change-logo/index.md
@@ -187,7 +187,7 @@ to customize FTW styles_**: <br />
 [How to customize FTW styles](/ftw-styling/how-to-customize-ftw-styles/)
 
 Especially, you should check
-[the best practices topic](/ftw-styling/how-to-customize-ftw-styles/#styling-guidelines-and-good-practices)
+[the best practices topic](/ftw-styling/how-to-customize-ftw-styles/#styling-guidelines)
 to check the philosophy of how the existing components are styled.
 
 <br />

--- a/src/docs/tutorial-branding/first-edit/index.md
+++ b/src/docs/tutorial-branding/first-edit/index.md
@@ -1,7 +1,7 @@
 ---
 title: First customization
 slug: first-edit
-updated: 2020-02-28
+updated: 2021-02-12
 category: tutorial-branding
 ingress: Change the marketplace color.
 published: true
@@ -13,13 +13,14 @@ Custom styling is a good starting point to introduce your own branding
 and remove design choices made for example marketplace, Saunatime.
 
 FTW templates have most of the styling tied to component directories,
-but there are a couple of files that define global CSS Properties and
-property sets:
+but there are 3 files that define custom media queries, default CSS
+Properties, and property sets:
 
 ```shell
 └── src
     └── styles
         ├── propertySets.css
+        ├── customMediaQueries.css
         └── marketplaceDefaults.css
 ```
 


### PR DESCRIPTION
- [x] And add article: [How code splitting works in FTW](https://deploy-preview-395--sharetribe-flex-docs-site.netlify.app/docs/ftw-routing/how-code-splitting-works-in-ftw/)
  link: `[code-splitting](/ftw-routing/how-code-splitting-works-in-ftw/)`
- [x] [How routing works in FTW](https://deploy-preview-395--sharetribe-flex-docs-site.netlify.app/docs/ftw-routing/how-routing-works-in-ftw/)
- [x] Tutorial: [First customization](https://deploy-preview-395--sharetribe-flex-docs-site.netlify.app/docs/tutorial-branding/first-edit/)
- [x] [How to customize FTW styles](https://deploy-preview-395--sharetribe-flex-docs-site.netlify.app/docs/ftw-styling/how-to-customize-ftw-styles/)

In the last article, I also shortened the sub headings:
<img width="263" alt="Screenshot 2021-02-12 at 18 53 06" src="https://user-images.githubusercontent.com/717315/107797445-a2799900-6d63-11eb-9582-34546ca1d400.png">
