### PR TITLE
Update default branch naming instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,9 @@ A:
 Read the [Writing articles for Flex Docs](./writing-articles.md)
 documentation and head on to the [src/docs/](../src/docs) directory.
 
-If you're unsure under which category the article should go, have a look at the [Docs site structure Whimsical board](https://whimsical.com/flex-docs-PEaMXJE9MB3vHXtP2VsgFX)
+If you're unsure under which category the article should go, have a look
+at the
+[Docs site structure Whimsical board](https://whimsical.com/flex-docs-PEaMXJE9MB3vHXtP2VsgFX)
 
 ## Q: I want to change some UI text on the Flex Docs site
 

--- a/src/docs/ftw-introduction/01-how-to-customize-ftw/index.md
+++ b/src/docs/ftw-introduction/01-how-to-customize-ftw/index.md
@@ -73,22 +73,30 @@ FTW, you should pull in changes from the upstream remote.
 > mainly think of FTW as being the starting point of your customization,
 > not something that is constantly updated as you make changes to it.
 
-In the `master` branch (or in the branch you want to merge in the
-upstream changes):
+Run the following commands in a feature branch
 
-1.  Fetch the latest changes from the upstream repository:
+1. Create a new feature branch and switch into that branch:
 
-    ```shell
-    git fetch upstream
-    ```
+   ```shell
+   git checkout -b updates-from-upstream
+   ```
 
-1.  Merge the changes to your local branch
+1. Fetch the latest changes from the upstream repository:
 
-    ```shell
-    git merge upstream/master
-    ```
+   ```shell
+   git fetch upstream
+   ```
 
-1.  Fix possible merge conflicts, commit, and push/deploy.
+1. Merge the changes to your local branch
+
+   ```shell
+   git merge upstream/master
+   ```
+
+   > FTW-daily and FTW-hourly still follow old Github convention to name
+   > the default branch as **master** instead of **main**.
+
+1. Fix possible merge conflicts, commit, and push/deploy.
 
 See also the
 [Syncing a fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork)

--- a/src/docs/operator-guides/hiring-developer-to-build-your-flex-marketplace/index.md
+++ b/src/docs/operator-guides/hiring-developer-to-build-your-flex-marketplace/index.md
@@ -108,11 +108,10 @@ The best way to get an accurate estimate of the time and budget required
 to build your unique marketplace is to get in touch with developers.
 With your requirements prepared, Sharetribe’s Flex partners can prepare
 a high-level estimate for you fast. To get in touch with them, go to
-your
-[Flex Console](https://flex-console.sharetribe.com/)
-and either submit your requirements through a form provided there, or
-book a free consultation call with one of Sharetribe's experts to
-discuss your requirements.
+your [Flex Console](https://flex-console.sharetribe.com/) and either
+submit your requirements through a form provided there, or book a free
+consultation call with one of Sharetribe's experts to discuss your
+requirements.
 
 ### Building a marketplace the Sharetribe way
 

--- a/src/docs/tutorial-branding/deploy-to-heroku/index.md
+++ b/src/docs/tutorial-branding/deploy-to-heroku/index.md
@@ -157,7 +157,7 @@ Go to the Deploy page of your new app and
 ![Heroku: Connect the app with Github repository](./heroku-connect-to-github.png)
 
 After that, you can deploy the app manually or enable automatic deploy
-from your master branch.
+from your default branch (usually named as _main_ or _master_).
 
 If everything works, your app should be available in URL that looks a
 bit like this: `https://<your-app-name>.herokuapp.com`

--- a/src/docs/tutorial/introduction/index.md
+++ b/src/docs/tutorial/introduction/index.md
@@ -57,6 +57,9 @@ up:
 1. Create a
    [Github repository](https://help.github.com/en/github/getting-started-with-github/create-a-repo).
 
+   > **Note**: do not initialize the repo with anything. You are
+   > importing an existing repository.
+
 1. On the command line, check your remote repositories:
 
    ```shell
@@ -118,11 +121,38 @@ up:
 
    </extrainfo>
 
-1. Push an existing repository from the command line
+1. Rename your local default branch as **main**
+
+   If you have cloned FTW-daily or FTW-hourly repository, the default
+   branch is following an old Github naming pattern.
 
    ```shell
-   git push -u origin master
+   git checkout master
+   git branch -m master main
    ```
+
+1) Push an existing repository from the command line
+
+   ```shell
+   git push -u origin main
+   ```
+
+   <extrainfo title="What's the difference between master and main?">
+
+   [Git](https://git-scm.com/about) is one of the most popular version
+   control systems. It creates a tree structure where each **commit**
+   (of code changes) creates a new node in that tree. The default branch
+   (trunk) has been traditionally called as **master**, but
+   [Github](https://github.com/about) has moved away from that naming
+   convention and has started to call the default branch as **main**.
+
+   FTW-daily and FTW-hourly have been created long time before that
+   naming convention changed, so they still use **master** as the name
+   of the default branch. However, Github is pushing the new naming
+   convention into use throughout their service and it's better if new
+   repositories follow that naming pattern.
+
+   </extrainfo>
 
 > **Note**: the examples above, used HTTPS remote URLs instead of SSH
 > remote URLs.<br /> Read more about


### PR DESCRIPTION
Github has changed default branch naming convention (master -> main) and also its own docs.

This update recommends that after cloning user:
1. changes branch name locally
    ```shell
    git branch -m master main
    ```

2. pushes the local default branch into newly created empty repo as **main**
    ```shell
    git push -u origin main
    ```
