### PR TITLE
Add listing approval instructions and update FTW-time to FTW-hourly

### DIFF
--- a/src/docs/background/features/index.md
+++ b/src/docs/background/features/index.md
@@ -1,7 +1,7 @@
 ---
 title: Features
 slug: features
-updated: 2019-11-21
+updated: 2021-09-30
 category: background
 ingress:
   This article provides an overview of the most important features of
@@ -88,7 +88,9 @@ A listing can have several different states:
 - **_Pending approval._** The listing is ready, but this marketplace
   requires the operator to approve each listing before they are
   published, so the listing is waiting for operator's approval before it
-  is published.
+  is published. You can enable or disable the listing approval
+  functionality for your marketplace in
+  [Flex CLI](/flex-cli/getting-started-with-flex-cli/#enable-and-disable-listing-approval-functionality).
 - **Closed.** The listing used to be published, but has since been
   closed, either by the provider or by the operator. The listing is
   still visible to the provider, but not discoverable via search.

--- a/src/docs/background/features/index.md
+++ b/src/docs/background/features/index.md
@@ -1,7 +1,7 @@
 ---
 title: Features
 slug: features
-updated: 2021-09-30
+updated: 2021-10-04
 category: background
 ingress:
   This article provides an overview of the most important features of

--- a/src/docs/background/how-sca-works/index.md
+++ b/src/docs/background/how-sca-works/index.md
@@ -21,9 +21,9 @@ means that an online payment has to be verified via a customer’s online
 bank or mobile verification when conducting the payment.
 
 The default [transaction process](/background/transaction-process/) of
-Sharetribe Flex and the
-[Flex Template for Web](https://github.com/sharetribe/flex-template-web)
-(FTW) offer out-of-the-box support for SCA. This article helps you
+Sharetribe Flex and the Flex Templates for Web (
+[FTW daily](https://github.com/sharetribe/ftw-daily), [FTW hourly](https://github.com/sharetribe/ftw-hourly), [FTW product](https://github.com/sharetribe/ftw-product)
+) offer out-of-the-box support for SCA. This article helps you
 understand how exactly transactions using SCA will work in the default
 process.
 

--- a/src/docs/background/how-sca-works/index.md
+++ b/src/docs/background/how-sca-works/index.md
@@ -1,7 +1,7 @@
 ---
 title: How Strong Customer Authentication works
 slug: strong-customer-authentication
-updated: 2019-07-02
+updated: 2021-10-04
 category: background
 ingress:
   This article gives an overview of Strong Customer Authentication, a

--- a/src/docs/background/using-stored-payment-cards/index.md
+++ b/src/docs/background/using-stored-payment-cards/index.md
@@ -15,7 +15,7 @@ future purchases. Doing this provides multiple benefits: it streamlines
 the checkout process for existing customers and allows you to place
 additional charges to the payment card of the customer.
 
-Flex Template for Web (FTW) includes a checkout workflow, which offers a
+Flex Templates for Web (FTW) include a checkout workflow, which offers a
 box for the customer to check if they want to store their card for
 future purchases. Once they've stored it, they are offered the option to
 use the same card for subsequent purchases without entering the details

--- a/src/docs/cookbook-transaction-process/change-transaction-process-in-ftw/index.md
+++ b/src/docs/cookbook-transaction-process/change-transaction-process-in-ftw/index.md
@@ -34,8 +34,8 @@ to match the process in our backend.
 > If you are using
 > [time-based availability](/references/availability/#time-based-availability-management)
 > in your marketplace, you can start with
-> [FTW-time](https://github.com/sharetribe/ftw-time), a beta version of
-> the template supporting time-based availability out of the box.
+> [FTW-hourly](https://github.com/sharetribe/ftw-hourly), the template
+> supporting time-based availability out of the box.
 
 ## 1. Change the transaction process alias
 

--- a/src/docs/cookbook-transaction-process/change-transaction-process-in-ftw/index.md
+++ b/src/docs/cookbook-transaction-process/change-transaction-process-in-ftw/index.md
@@ -9,8 +9,8 @@ ingress:
 published: true
 ---
 
-The default transaction process in FTW is a nightly booking process
-called `flex-default-process/release-1` and FTW is created to support
+The default transaction process in FTW-daily is a nightly booking process
+called `flex-default-process/release-1` and FTW-daily is created to support
 states and transitions defined in that process.
 
 How the transaction process works behind the Marketplace API depends on
@@ -29,7 +29,7 @@ The following guide will help you to customise the process flow in FTW
 to match the process in our backend.
 
 > **Note:** By default,
-> [FTW](https://github.com/sharetribe/flex-template-web/) is using
+> [FTW-daily](https://github.com/sharetribe/ftw-daily/) is using
 > [day-based availability](/references/availability/#day-based-availability-management).
 > If you are using
 > [time-based availability](/references/availability/#time-based-availability-management)

--- a/src/docs/flex-cli/getting-started-with-flex-cli/index.md
+++ b/src/docs/flex-cli/getting-started-with-flex-cli/index.md
@@ -1,7 +1,7 @@
 ---
 title: Getting started with Flex CLI
 slug: getting-started-with-flex-cli
-updated: 2019-09-10
+updated: 2021-09-30
 category: flex-cli
 ingress:
   This tutorial shows you how to get started with the Flex CLI. You will
@@ -134,12 +134,31 @@ flex-cli process list -m my-test-marketplace
 This command shows you a list of transaction processes in your
 marketplace.
 
+## Enable and disable listing approval functionality
+
+Flex has a functionality to require operator approval for listings
+before publishing them. This listing approval feature can be disabled
+and enabled using Flex CLI.
+
+```bash
+#To see whether your marketplace requires listings to be approved
+flex-cli listing-approval -m [your-marketplace]
+
+#To enable listing approval for your marketplace
+flex-cli listing-approval enable -m [your-marketplace]
+
+#To disable listing approval for your marketplace
+flex-cli listing-approval disable -m [your-marketplace]
+
+```
+
 ## Summary
 
 In this tutorial, we installed Flex CLI, logged in using an API key and
 tried some example commands. In addition, we familiarized ourselves with
 the `help` command that is the main source of documentation for the Flex
-CLI.
+CLI. We also learned how to disable and enable the listing approval
+functionality for our marketplace.
 
 Now that we know how to list processes, the next this is to
 [make a small change to the existing process](/flex-cli/edit-transaction-process-with-flex-cli/).

--- a/src/docs/flex-cli/getting-started-with-flex-cli/index.md
+++ b/src/docs/flex-cli/getting-started-with-flex-cli/index.md
@@ -1,7 +1,7 @@
 ---
 title: Getting started with Flex CLI
 slug: getting-started-with-flex-cli
-updated: 2021-09-30
+updated: 2021-10-04
 category: flex-cli
 ingress:
   This tutorial shows you how to get started with the Flex CLI. You will

--- a/src/docs/ftw-introduction/ftw-hourly/index.md
+++ b/src/docs/ftw-introduction/ftw-hourly/index.md
@@ -22,9 +22,9 @@ which is a unit-based process and has value `time` in
 
 > **Note:** `BookingDatesForm` and `EditListingAvailabilityForm`
 > components have been removed from the template as they are heavily
-> related to the day-based process. If you have started with FTW and you
-> are planning to move to FTW-time, you should check if you have done
-> any customization to these components.
+> related to the day-based process. If you have started with FTW-daily
+> and you are planning to move to FTW-hourly, you should check if you
+> have done any customization to these components.
 
 ## Handling time zones
 
@@ -33,7 +33,7 @@ and day-based ones. This is the case especially if your marketplace
 operates on multiple time zones and some listings could be booked from a
 different time zone as the one in which the listing is located.
 
-FTW-time introduces a new library `moment-timezone` for handling the
+FTW-hourly introduces a new library `moment-timezone` for handling the
 time zones when operating with dates. You need to use the
 moment-timezone whenever you create new date objects. E.g. on
 ListingPage the start and end of the month should have time zone so that
@@ -47,13 +47,13 @@ component will select browser's time zone.
 
 ## Booking the listing
 
-In FTW-time, the default minimum duration of the booking is 1 hour and
+In FTW-hourly, the default minimum duration of the booking is 1 hour and
 the available booking times are starting on sharp hours (e.g. 9:00,
 10:00, etc). Since the minimum duration of a timeslot is 5 minutes and
 starting times can be customized to support different use-cases, you
 might want to change the duration or timing of your timeslot-units.
 Start this process from
-[util/dates.js](https://github.com/sharetribe/ftw-time/blob/master/src/util/dates.js)
+[util/dates.js](https://github.com/sharetribe/ftw-hourly/blob/master/src/util/dates.js)
 file. You should edit at least the `findNextBoundary`, `getSharpHours`
 and `calculateQuantityFromHours` functions.
 
@@ -98,4 +98,5 @@ to do to template if you want to enable multiple listings:
   `disableProfileLink` flag.
 
 You can see all the changes we did when changing Saunatime to Yogatime
-in this [pull request](https://github.com/sharetribe/ftw-time/pull/56).
+in this
+[pull request](https://github.com/sharetribe/ftw-hourly/pull/56).

--- a/src/docs/references/availability/index.md
+++ b/src/docs/references/availability/index.md
@@ -105,9 +105,9 @@ availability plan for a listing can be found in the
 > [Flex Template for Web](https://github.com/sharetribe/flex-template-web/)
 > uses day-based availability. If you want to use time-based
 > availability in your marketplace instead, it's recommended that you
-> start with [FTW-time](https://github.com/sharetribe/ftw-time), a beta
-> version of a new Flex Template for Web, which supports time-based
-> availability out of the box.
+> start with [FTW-hourly](https://github.com/sharetribe/ftw-hourly), the
+> Flex Template for Web that supports time-based availability out of the
+> box.
 
 ### Timeslots, availability plans and exceptions
 

--- a/src/docs/references/availability/index.md
+++ b/src/docs/references/availability/index.md
@@ -102,7 +102,7 @@ availability plan for a listing can be found in the
 [time-based bookings cookbook](/cookbook-transaction-process/enable-time-based-bookings-into-use/).
 
 > **Note:** By default,
-> [Flex Template for Web](https://github.com/sharetribe/flex-template-web/)
+> [FTW-daily](https://github.com/sharetribe/ftw-daily/)
 > uses day-based availability. If you want to use time-based
 > availability in your marketplace instead, it's recommended that you
 > start with [FTW-hourly](https://github.com/sharetribe/ftw-hourly), the


### PR DESCRIPTION
- Update obsolete 'FTW-time' references into 'FTW-hourly' references
- Add instructions on how to enable and disable listing approval functionality in Flex CLI.