### PR TITLE
fix date typo and adds 1 example

### DIFF
--- a/src/docs/references/availability/index.md
+++ b/src/docs/references/availability/index.md
@@ -1,7 +1,7 @@
 ---
 title: Listing availability management
 slug: availability
-updated: 2020-09-24
+updated: 2020-10-05
 category: references
 ingress: Reference documentation for listing availability management.
 published: true
@@ -84,9 +84,15 @@ An exception with start `2018-11-26T00:30.000+01:00` and end
 
 ###### **Example 3:**
 
-Given exception 1 from `2017-11-26T10:00:00.000Z` to
+An exception with start `2018-11-26T00:30.000+01:00` and end
+`2018-11-27T15:15:00.000+01:00` is interpreted as if it were from
+`2018-11-25T00:00:00.000Z` to `2018-11-28T00:00:00.000Z`.
+
+###### **Example 4:**
+
+Given exception 1 from `2018-11-26T10:00:00.000Z` to
 `2018-11-26T12:00:00.000Z` with 1 seat and exception 2 from
-`2017-11-26T10:00:00.000Z` to `2018-11-26T12:00:00.000Z` with 0 seats,
+`2018-11-26T10:00:00.000Z` to `2018-11-26T12:00:00.000Z` with 0 seats,
 this is interpreted as if single exception existed from
 `2018-11-26T00:00:00.0Z` to `2018-11-27T00:00:00.000Z` with 0 seats.
 


### PR DESCRIPTION
added 1 example cause I got super confused by "example 2". Probably not needed for developers that are super familiar with timestamps, but well, it can't hurt.