### PR TITLE
Fix typos in FTW-hourly introduction

### DIFF
--- a/src/docs/ftw-introduction/ftw-hourly/index.md
+++ b/src/docs/ftw-introduction/ftw-hourly/index.md
@@ -10,7 +10,7 @@ published: true
 ---
 
 [FTW-hourly](https://github.com/sharetribe/ftw-hourly) is a Flex
-Template for Web with support for time-based bookings and it's build
+Template for Web with support for time-based bookings and it's built
 with service marketplaces in mind. This template introduces Yogatime - a
 fictional marketplace for booking yoga classes from various yoga
 teachers.

--- a/src/docs/ftw-introduction/ftw-hourly/index.md
+++ b/src/docs/ftw-introduction/ftw-hourly/index.md
@@ -84,17 +84,17 @@ zone of the listing to availability plan.
 
 ## Each provider can have only one listing
 
-Because FTW-hourly has been build keeping the service marketplaces each
-user can have only one listing by default. In Yogatime's context the
-listing is handled as teacher profile. There are some changeds you need
-to do to template if you want to enable multiple listings:
+Because FTW-hourly has been built with a focus on service marketplaces, each
+user can only have one listing by default. In Yogatime's context, the
+listing is set up as a teacher profile. There are some changes you need
+to make to the template if you want to enable multiple listings:
 
-- Remove `allowOnlyOneListing` prop routing to `EditListingPage`
-- Add link to `NewListingPage` e.g. to `Topbar`
-- Add `ManageListingsPage` to routing and add link to that page e.g. to
+- Remove `allowOnlyOneListing` prop from `EditListingPage` routing in `routeConfiguration.js`
+- Add a link to `NewListingPage` e.g. to `Topbar`
+- Add `ManageListingsPage` to routing, and add a link to that page e.g. in
   `UserNav`
-- Change `OwnListingLink` to the link to user profile. Note that with
-  `Avatar` component you can enable the profile link by removing
+- Change `OwnListingLink` to direct to user profile. Note that in the
+  `Avatar` component you can enable the profile link by removing the
   `disableProfileLink` flag.
 
 You can see all the changes we did when changing Saunatime to Yogatime


### PR DESCRIPTION
The FTW-hourly introduction section had typos and unclarities in the section dealing with changing from single listing mode to multiple listing mode. Fix the typos and clarify the instructions.