### PR TITLE
Remove references to deprecated commission actions

### DIFF
--- a/src/docs/background/commissions-and-monetizing-your-platform/index.md
+++ b/src/docs/background/commissions-and-monetizing-your-platform/index.md
@@ -83,9 +83,9 @@ const customerCommission = {
 const lineItems = [booking, providerCommission, customerCommission];
 ```
 
-For a 100 EUR listing, this would result in a 110 EUR payin for the customer
-and a 88 EUR payout for the provider. The marketplace would receive 22
-EUR minus Stripe fees.
+For a 100 EUR listing, this would result in a 110 EUR payin for the
+customer and a 88 EUR payout for the provider. The marketplace would
+receive 22 EUR minus Stripe fees.
 
 <extrainfo title="Negative or positive commission?">
 Commission line items are defined as either positive or negative depending on the transaction

--- a/src/docs/cookbook-transaction-process/enable-time-based-bookings/index.md
+++ b/src/docs/cookbook-transaction-process/enable-time-based-bookings/index.md
@@ -1,7 +1,7 @@
 ---
 title: Enable time-based bookings into use
 slug: enable-time-based-bookings-into-use
-updated: 2021-12-16
+updated: 2021-12-23
 category: cookbook-transaction-process
 ingress:
   Time-based bookings and availability management enable low level fine

--- a/src/docs/cookbook-transaction-process/enable-time-based-bookings/index.md
+++ b/src/docs/cookbook-transaction-process/enable-time-based-bookings/index.md
@@ -1,7 +1,7 @@
 ---
 title: Enable time-based bookings into use
 slug: enable-time-based-bookings-into-use
-updated: 2019-10-24
+updated: 2021-12-16
 category: cookbook-transaction-process
 ingress:
   Time-based bookings and availability management enable low level fine
@@ -27,9 +27,7 @@ have something like the following in your `process.edn` file:
  :actions
  [{:name :action/create-pending-booking,
    :config {:type :time}}
-  {:name :action/calculate-tx-unit-total-price}
-  {:name :action/calculate-tx-provider-commission,
-   :config {:commission 0.1M}}
+ {:name :action/privileged-set-line-items}
   {:name :action/stripe-create-payment-intent}],
  :to :state/pending-payment}
 {:name :transition/request-payment-after-enquiry,
@@ -37,9 +35,7 @@ have something like the following in your `process.edn` file:
  :actions
  [{:name :action/create-pending-booking,
    :config {:type :time}}
-  {:name :action/calculate-tx-unit-total-price}
-  {:name :action/calculate-tx-provider-commission,
-   :config {:commission 0.1M}}
+ {:name :action/privileged-set-line-items}
   {:name :action/stripe-create-payment-intent}],
  :from :state/enquiry,
  :to :state/pending-payment}

--- a/src/docs/flex-cli/edit-transaction-process-with-flex-cli/index.md
+++ b/src/docs/flex-cli/edit-transaction-process-with-flex-cli/index.md
@@ -22,9 +22,9 @@ If you haven't read
 [how transaction processes work in Flex](/background/transaction-process/),
 it's a good idea to do that before starting this tutorial.
 
-In this tutorial we change the marketplace commission percantage. After
-we've made the change, we'll push the updated transaction process
-version and update the existing alias.
+In this tutorial we extend the marketplace review period. After we've
+made the change, we'll push the updated transaction process version and
+update the existing alias.
 
 Let's get started!
 
@@ -155,7 +155,7 @@ review period to 10 days.
 ```diff
  {:format :v3
   :transitions
-  [{:name :transition/enquire, 
+  [{:name :transition/enquire,
     ...
   {:name :transition/expire-review-period,
    :at
@@ -257,13 +257,14 @@ add/remove/rename states or transitions, updating alias may potentially
 break your marketplace front-end if you haven't updated it to work with
 the new process.
 
-The commission is now changed! Next time you initiate a new transaction
-with the alias `preauth-with-booking/release-1` it uses 30% commission.
+The review period has now been changed! Next time you initiate a new
+transaction with the alias `preauth-with-booking/release-1` the review
+period is 10 days.
 
 ## Summary
 
 In this tutorial we pulled an existing process definition with the Flex
-CLI. We changed the commission percentage to 30%, validated the process
+CLI. We extended the review period to 10 days, validated the process
 file and pushed it back to Flex. Finally, we updated the alias to point
 to the new version.
 

--- a/src/docs/flex-cli/edit-transaction-process-with-flex-cli/index.md
+++ b/src/docs/flex-cli/edit-transaction-process-with-flex-cli/index.md
@@ -1,7 +1,7 @@
 ---
 title: Edit transaction process with Flex CLI
 slug: edit-transaction-process-with-flex-cli
-updated: 2021-12-16
+updated: 2021-12-23
 category: flex-cli
 ingress:
   This tutorial shows you how to edit transaction process with Flex CLI.

--- a/src/docs/flex-cli/edit-transaction-process-with-flex-cli/index.md
+++ b/src/docs/flex-cli/edit-transaction-process-with-flex-cli/index.md
@@ -1,7 +1,7 @@
 ---
 title: Edit transaction process with Flex CLI
 slug: edit-transaction-process-with-flex-cli
-updated: 2020-10-29
+updated: 2021-12-16
 category: flex-cli
 ingress:
   This tutorial shows you how to edit transaction process with Flex CLI.
@@ -126,7 +126,7 @@ clarity.
 Now that you know the basics of the edn format, let's edit the
 `process.edn` file!
 
-## Change the commission
+## Extend the review period
 
 Open the `process.edn` in your favorite editor.
 
@@ -139,45 +139,48 @@ From the `process.edn` file, you'll find a map with a key
 transition in your marketplace. Each transition contains values for keys
 like `:name`, `:actor`, `:actions`, `:to` and `:from`.
 
-To change the commission percentage of the transaction process, we need
-to find the transaction where the commission is calculated. The
-commission is calculated by an action named
-`:action/calculate-tx-provider-commission` (or
-`:action/calculate-tx-customer-commission` if customer commission is in
-use). In the `preauth-with-nightly-booking` process, the commission in
-calculated in transitions `:transition/request-payment` and
-`:transition/request-payment-after-enquiry`.
+To extend the review period in the transaction process, we need to find
+the transition where the review periods are defined. In the Flex default
+processes, the review period length is defined in the transition
+`:transition/expire-review-period`, and if one participant has already
+reviewed the other, in either
+`:transition/expire-provider-review-period` or
+`:transition/expire-customer-review-period`. By default, the review
+periods are defined as 7 days.
 
-When you have found the actions that calculate commission, change the
-value of the `:commission` in the action `:config` to `0.3M` (which
-means 30%):
+When you have found the transitions, change the value of the
+`:fn/period` in the `:at` time expression to `["P10D"]` to extend the
+review period to 10 days.
 
 ```diff
  {:format :v3
   :transitions
-  [{:name :transition/enquire
-    :actor :actor.role/customer
-    :actions []
-    :to :state/enquiry}
-   {:name :transition/request-payment
-    :actor :actor.role/customer
-    :actions [{:name :action/create-pending-booking}
-              {:name :action/calculate-tx-nightly-total-price}
-              {:name :action/calculate-tx-provider-commission
--              :config {:commission 0.1M}}
-+              :config {:commission 0.3M}}
-              {:name :action/stripe-create-payment-intent}]
-    :to :state/pending-payment}
-   {:name :transition/request-payment-after-enquiry
-    :actor :actor.role/customer
-    :actions [{:name :action/create-pending-booking}
-              {:name :action/calculate-tx-nightly-total-price}
-              {:name :action/calculate-tx-provider-commission
--              :config {:commission 0.1M}}
-+              :config {:commission 0.3M}}
-              {:name :action/stripe-create-payment-intent}]
-    :from :state/enquiry
-    :to :state/pending-payment}
+  [{:name :transition/enquire, 
+    ...
+  {:name :transition/expire-review-period,
+   :at
+   {:fn/plus
+-    [{:fn/timepoint [:time/booking-end]} {:fn/period ["P7D"]}]},
++    [{:fn/timepoint [:time/booking-end]} {:fn/period ["P10D"]}]},
+   :actions [],
+   :from :state/delivered,
+   :to :state/reviewed}
+  {:name :transition/expire-provider-review-period,
+   :at
+   {:fn/plus
+-    [{:fn/timepoint [:time/booking-end]} {:fn/period ["P7D"]}]},
++    [{:fn/timepoint [:time/booking-end]} {:fn/period ["P10D"]}]},
+   :actions [{:name :action/publish-reviews}],
+   :from :state/reviewed-by-customer,
+   :to :state/reviewed}
+  {:name :transition/expire-customer-review-period,
+   :at
+   {:fn/plus
+-    [{:fn/timepoint [:time/booking-end]} {:fn/period ["P7D"]}]},
++    [{:fn/timepoint [:time/booking-end]} {:fn/period ["P10D"]}]},
+   :actions [{:name :action/publish-reviews}],
+   :from :state/reviewed-by-provider,
+   :to :state/reviewed}
 ```
 
 Save the changes you've made to `process.edn` file.

--- a/src/docs/references/transaction-process-format/index.md
+++ b/src/docs/references/transaction-process-format/index.md
@@ -1,7 +1,7 @@
 ---
 title: Transaction process format
 slug: transaction-process-format
-updated: 2021-12-16
+updated: 2021-12-23
 category: references
 ingress:
   This reference article describes the format of the process.edn file

--- a/src/docs/references/transaction-process-format/index.md
+++ b/src/docs/references/transaction-process-format/index.md
@@ -1,7 +1,7 @@
 ---
 title: Transaction process format
 slug: transaction-process-format
-updated: 2019-10-02
+updated: 2021-12-16
 category: references
 ingress:
   This reference article describes the format of the process.edn file
@@ -45,7 +45,7 @@ The annotated process description for this process is as follows:
 
                 ;; The actions that the transaction engine executes when the transition is taken.
                 :actions [{:name :action/create-pending-booking
-                           :config {:type :day}}
+                           :config {:type :time}}
                           {:name :privileged-set-line-items}
                           {:name :action/stripe-create-payment-intent}]
 
@@ -271,8 +271,7 @@ transition.
 
 In our example process, the `:transition/request-payment` defines the
 actions `action/create-pending-booking`,
-`action/calculate-tx-nightly-total-price`,
-`action/calculate-tx-provider-commission` and
+`action/privileged-set-line-items` and
 `action/stripe-create-payment-intent`. This means the transition
 requires and accepts the following parameters defined by the
 `action/create-pending-booking`:
@@ -280,15 +279,18 @@ requires and accepts the following parameters defined by the
 - `bookingStart`, `bookingEnd`: timestamp, mandatory
 - `bookingDisplayStart`, `bookingDisplayEnd`: timestamp, optional
 
+as well as the following parameters defined by the
+`action/privileged-set-line-items`:
+
+- `lineItems`,
+  [line item array](/references/transaction-process-actions/#pricing),
+  mandatory
+
 plus the following parameters defined by the
 `action/stripe-create-payment-intent`:
 
 - `paymentMethod`: string, mandatory
 - `setupPaymentMethodForSaving`: boolean, optional, defaults to `false`
-
-The other two actions, `action/calculate-tx-nightly-total-price` and
-`action/calculate-tx-provider-commission`, do not define any parameters
-(but they do have preconditions).
 
 ### Configuration options
 
@@ -304,11 +306,11 @@ description via the `:config` key in the action definition:
 ```clojure
 {
  ;; Name of the action.
- :name :action/calculate-tx-provider-commission
+ :name :action/create-pending-booking
 
  ;; The configuration options map.
  ;; Can be omitted if no options need to be passed.
- :config {:commission 0.1M}}
+ :config {:type :time}}
 ```
 
 You can see all the preconditions, action parameters and configuration
@@ -393,9 +395,8 @@ Actions
 
 Name                                      Config
 :action.initializer/init-listing-tx
-:action/create-pending-booking            {:type :day}
-:action/calculate-tx-nightly-total-price
-:action/calculate-tx-provider-commission  {:commission 0.1}
+:action/create-pending-booking            {:type :time}
+:action/privileged-set-line-items
 :action/stripe-create-payment-intent
 
 Notifications
@@ -444,16 +445,16 @@ requires and accepts.
 
 ### Action
 
-| Key       | Type    | Description                                              | Example                                    |
-| --------- | ------- | -------------------------------------------------------- | ------------------------------------------ |
-| `:name`   | Keyword | Reference to an action to use.                           | `:action/calculate-tx-provider-commission` |
-| `:config` | Map     | A map from action configuration options to their values. | `{:commission 0.1M}`                       |
+| Key       | Type    | Description                                              | Example                          |
+| --------- | ------- | -------------------------------------------------------- | -------------------------------- |
+| `:name`   | Keyword | Reference to an action to use.                           | `:action/create-pending-booking` |
+| `:config` | Map     | A map from action configuration options to their values. | `{:type :time}`                  |
 
 **Example**:
 
 ```clojure
-{:name :action/calculate-tx-provider-commission
- :config {:commission 0.15M}}
+{:name :action/create-pending-booking
+ :config {:type :time}}
 ```
 
 ### Notification

--- a/src/docs/tutorial-transaction-process/create-transaction-process/index.md
+++ b/src/docs/tutorial-transaction-process/create-transaction-process/index.md
@@ -448,7 +448,9 @@ with
 in your email notification templates. The next step in the tutorial
 deals with updating email notifications.
 
-The email templates that list the full line items in the default transaction process are
+The email templates that list the full line items in the default
+transaction process are
+
 - `new-booking-request` (to provider)
 - `booking-request-accepted` (to customer)
 - `money-paid` (to provider)

--- a/src/docs/tutorial-transaction-process/customize-pricing/index.md
+++ b/src/docs/tutorial-transaction-process/customize-pricing/index.md
@@ -676,7 +676,9 @@ The <a href="/tutorial-transaction-process/use-protected-data-in-emails/">third 
       {{/each}}
 ```
 
-The email templates that list the full line items in the default transaction process are
+The email templates that list the full line items in the default
+transaction process are
+
 - `new-booking-request` (to provider)
 - `booking-request-accepted` (to customer)
 - `money-paid` (to provider)


### PR DESCRIPTION
Some Docs articles referenced deprecated transaction process actions for setting commissions in code examples. This PR replaces those references with up-to-date examples.