### PR TITLE
Add Heroku related warnings to relevant articles

### DIFF
--- a/src/docs/ftw-hosting/how-to-deploy-ftw-to-production/index.md
+++ b/src/docs/ftw-hosting/how-to-deploy-ftw-to-production/index.md
@@ -117,7 +117,7 @@ _Note: The Heroku Github integration is currently unavailable. You can
 connect your app as a
 [remote repository on your local codebase](https://devcenter.heroku.com/articles/git#create-a-heroku-remote)
 and
-[pushing your changes to the remote](https://devcenter.heroku.com/articles/git#deploy-your-code)
+[push your changes to the remote](https://devcenter.heroku.com/articles/git#deploy-your-code)
 for deployment._
 
 - [Fork the repository](#fork-the-repository)

--- a/src/docs/ftw-hosting/how-to-deploy-ftw-to-production/index.md
+++ b/src/docs/ftw-hosting/how-to-deploy-ftw-to-production/index.md
@@ -11,6 +11,13 @@ published: true
 
 ## Getting started
 
+**Note: Heroku has been having some
+[security issues](https://status.heroku.com/incidents/2413), and until
+they are resolved, we recommend caution when using Heroku. Furthermore,
+the Heroku integration with Github is currently not available. We are
+looking into alternative deployment recommendations while the situation
+continues.**
+
 The easiest way to get started is deploying the application to Heroku.
 Before creating the app you need three accounts:
 [Heroku](https://www.heroku.com/), [Stripe](https://stripe.com/) and
@@ -105,6 +112,13 @@ yarn start
 ```
 
 ## Deploying to Heroku
+
+_Note: The Heroku Github integration is currently unavailable. You can
+connect your app as a
+[remote repository on your local codebase](https://devcenter.heroku.com/articles/git#create-a-heroku-remote)
+and
+[pushing your changes to the remote](https://devcenter.heroku.com/articles/git#deploy-your-code)
+for deployment._
 
 - [Fork the repository](#fork-the-repository)
 - [Create a new app](#create-a-new-app)

--- a/src/docs/tutorial-branding/deploy-to-heroku/index.md
+++ b/src/docs/tutorial-branding/deploy-to-heroku/index.md
@@ -48,6 +48,13 @@ environment, "window" object is not available.
 
 ## Deploy to Heroku
 
+**Note: Heroku has been having some
+[security issues](https://status.heroku.com/incidents/2413), and until
+they are resolved, we recommend caution when using Heroku. Furthermore,
+the Heroku integration with Github is currently not available. We are
+looking into alternative deployment recommendations while the situation
+continues.**
+
 Generic Heroku deployment has the following steps:
 
 **Step 1: Create a Heroku account**
@@ -126,9 +133,8 @@ Then add the following environment variables as Config Vars:
 - `REACT_APP_CSP`
 
   Content Security Policy (CSP). Read more from
-  [this article](/ftw/how-to-set-up-csp-for-ftw/).<br />
-  Accepts values: _block_ and _report_. The recommended value is
-  _block_.
+  [this article](/ftw/how-to-set-up-csp-for-ftw/).<br /> Accepts values:
+  _block_ and _report_. The recommended value is _block_.
 
 - `REACT_APP_AVAILABILITY_ENABLED`
 
@@ -150,6 +156,13 @@ _heroku/nodejs_
 ![Add buildpack](./heroku-add-buildpack.png)
 
 **Step 5: Connect the Heroku app to Github**
+
+_Note: The Heroku Github integration is currently unavailable. You can
+connect your app as a
+[remote repository on your local codebase](https://devcenter.heroku.com/articles/git#create-a-heroku-remote)
+and
+[pushing your changes to the remote](https://devcenter.heroku.com/articles/git#deploy-your-code)
+for deployment._
 
 Go to the Deploy page of your new app and
 [connect the app with Github](https://devcenter.heroku.com/articles/github-integration#enabling-github-integration).

--- a/src/docs/tutorial-branding/deploy-to-heroku/index.md
+++ b/src/docs/tutorial-branding/deploy-to-heroku/index.md
@@ -161,7 +161,7 @@ _Note: The Heroku Github integration is currently unavailable. You can
 connect your app as a
 [remote repository on your local codebase](https://devcenter.heroku.com/articles/git#create-a-heroku-remote)
 and
-[pushing your changes to the remote](https://devcenter.heroku.com/articles/git#deploy-your-code)
+[push your changes to the remote](https://devcenter.heroku.com/articles/git#deploy-your-code)
 for deployment._
 
 Go to the Deploy page of your new app and


### PR DESCRIPTION
Heroku is having security issues, so add a warning in relevant articles that we're aware of the situation and looking into alternatives.