### PR TITLE
Connect mentions of webhooks with events

### DIFF
--- a/src/docs/operator-guides/concepts/index.md
+++ b/src/docs/operator-guides/concepts/index.md
@@ -107,7 +107,9 @@ A way to send automatic and/or manual messages to external applications
 marketplace. In practice, this is done with JSON messages that are
 delivered via HTTPS to the endpoints the admin chooses.
 
-Planned.
+Flex does not offer webhooks. Instead, Flex exposes
+[events](/references/events/) that allow you to achieve many of the use
+cases where webhooks would be used.
 
 ## Marketplace concepts
 

--- a/src/docs/references/events/index.md
+++ b/src/docs/references/events/index.md
@@ -28,7 +28,7 @@ solving use cases such as synchronizing changes in marketplace data into
 external places, e.g. a CRM, a spreadsheet or a calendar. It also allows
 programs to react to logical actions as part of the marketplace flows.
 For example, setting a field in user metadata can trigger an integration
-to publish the user's listings. Using events, it is possible to cover many of the use cases where other applications use webhooks.
+to publish the user's listings. Using events makes it possible to cover many of the use cases where other applications use webhooks.
 
 Currently, Flex exposes events by allowing them to be queried via the
 [Integration API](https://www.sharetribe.com/api-reference/integration.html#query-events)

--- a/src/docs/references/events/index.md
+++ b/src/docs/references/events/index.md
@@ -28,7 +28,7 @@ solving use cases such as synchronizing changes in marketplace data into
 external places, e.g. a CRM, a spreadsheet or a calendar. It also allows
 programs to react to logical actions as part of the marketplace flows.
 For example, setting a field in user metadata can trigger an integration
-to publish the user's listings. Events cover many of the use cases where other applications use webhooks.
+to publish the user's listings. Using events, it is possible to cover many of the use cases where other applications use webhooks.
 
 Currently, Flex exposes events by allowing them to be queried via the
 [Integration API](https://www.sharetribe.com/api-reference/integration.html#query-events)

--- a/src/docs/references/events/index.md
+++ b/src/docs/references/events/index.md
@@ -28,7 +28,7 @@ solving use cases such as synchronizing changes in marketplace data into
 external places, e.g. a CRM, a spreadsheet or a calendar. It also allows
 programs to react to logical actions as part of the marketplace flows.
 For example, setting a field in user metadata can trigger an integration
-to publish the user's listings.
+to publish the user's listings. Events cover many of the use cases where other applications use webhooks.
 
 Currently, Flex exposes events by allowing them to be queried via the
 [Integration API](https://www.sharetribe.com/api-reference/integration.html#query-events)


### PR DESCRIPTION
- Remove the mention of planned webhooks
- Mention events in the context of webhooks and vice versa