### PR TITLE
Sharetribe scripts v6 (propertySets.css is removed)

### DIFF
--- a/src/components/ArticlePage/ArticlePage.js
+++ b/src/components/ArticlePage/ArticlePage.js
@@ -225,8 +225,10 @@ const ArticlePage = props => {
             />
             <Updated date={updated} />
           </CrumbWrapper>
-          <Heading className='docSearch-h1'>{title}</Heading>
-          <ArticleIngress className='docSearch-ingress'>{ingress}</ArticleIngress>
+          <Heading className="docSearch-h1">{title}</Heading>
+          <ArticleIngress className="docSearch-ingress">
+            {ingress}
+          </ArticleIngress>
           <Info frontmatter={frontmatter} />
           <MobileTocWrapper>
             <ContentTocHeader>
@@ -238,7 +240,7 @@ const ArticlePage = props => {
               maxDepth={3}
             />
           </MobileTocWrapper>
-          <Markdown className='docSearch-content' htmlAst={htmlAst} />
+          <Markdown className="docSearch-content" htmlAst={htmlAst} />
 
           <NextAndPrevArticles
             slug={slug}

--- a/src/components/GlobalStyle.js
+++ b/src/components/GlobalStyle.js
@@ -20,7 +20,8 @@ const GlobalStyle = createGlobalStyle`
   .DocSearch.DocSearch-Button {
     background-color: #f9f9f9;
     &:hover {
-      box-shadow: inset 0 0 0 1px ${props => props.theme.searchInputBorderColor};
+      box-shadow: inset 0 0 0 1px ${props =>
+        props.theme.searchInputBorderColor};
     }
   }
 

--- a/src/components/Topbar/Search.js
+++ b/src/components/Topbar/Search.js
@@ -18,21 +18,19 @@ const Wrapper = styled.div`
     padding: 16px 0;
     margin-left: auto;
     margin-right: 40px;
-
   }
 `;
 
 const Search = props => {
-
   const { ...rest } = props;
 
   return (
     <Wrapper {...rest}>
-        <DocSearch
-          appId="IPOXPQ3KFI"
-          apiKey="48fd5d7d401d024a0b034f9e62b1cd34"
-          indexName="sharetribe"
-/>
+      <DocSearch
+        appId="IPOXPQ3KFI"
+        apiKey="48fd5d7d401d024a0b034f9e62b1cd34"
+        indexName="sharetribe"
+      />
     </Wrapper>
   );
 };

--- a/src/config-site-structure.js
+++ b/src/config-site-structure.js
@@ -77,8 +77,8 @@ const sortingArrayTransactionProcess = [
 
 const sortingArrayUsersAndAuthentication = [
   'users-and-authentication-in-flex',
-  'social-logins-and-sso'
-]
+  'social-logins-and-sso',
+];
 
 const sortingArrayPayments = [
   'payments-overview',
@@ -125,7 +125,7 @@ const sortingArrayFTWIntroduction = [
 const sortingArrayListings = [
   'listings-overview',
   'how-the-listing-search-works',
-  'requiring-approval'
+  'requiring-approval',
 ];
 
 exports.siteStructure = [
@@ -167,10 +167,11 @@ exports.siteStructure = [
     id: 'concepts',
     isOpen: false,
     subcategories: [
-      { id: 'concepts-users-and-authentication',
+      {
+        id: 'concepts-users-and-authentication',
         sortingArray: sortingArrayUsersAndAuthentication,
       },
-      { 
+      {
         id: 'concepts-listings',
         sortingArray: sortingArrayListings,
       },

--- a/src/docs/concepts-users-and-authentication/users-and-authentication-in-flex/index.md
+++ b/src/docs/concepts-users-and-authentication/users-and-authentication-in-flex/index.md
@@ -4,7 +4,8 @@ slug: users-and-authentication-in-flex
 updated: 2022-05-16
 category: concepts-users-and-authentication
 ingress:
-  This article explains how users are managed and how authentication and authorization works in Flex.
+  This article explains how users are managed and how authentication and
+  authorization works in Flex.
 published: true
 ---
 

--- a/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
+++ b/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
@@ -33,17 +33,24 @@ template application:
         └── propertySets.css
 ```
 
-In previous versions of FTW, there has been a third CSS
-file: propertySets.css. This file contains [CSS Property Sets](https://chromestatus.com/feature/5753701012602880) that can be applied to component styles using the `@apply`syntax.
-However, W3C decided not to include that feature in future CSS syntax, and the [postcss-apply plugin](https://github.com/pascalduez/postcss-apply) got deprecated in the process.
+In previous versions of FTW, there has been a third CSS file:
+propertySets.css. This file contains
+[CSS Property Sets](https://chromestatus.com/feature/5753701012602880)
+that can be applied to component styles using the `@apply`syntax.
+However, W3C decided not to include that feature in future CSS syntax,
+and the
+[postcss-apply plugin](https://github.com/pascalduez/postcss-apply) got
+deprecated in the process.
 
-If you have an older FTW template (earlier than FTW-daily v9,
-FTW-hourly v11 or FTW-product v10), you might have this file in your
-codebase. If you start using sharetribe-scripts v6.0.0, you need to
-consider migrating away from that since it contains code that is
-deprecated in v6.0.0 of sharetribe-scripts.
+If you have an older FTW template (earlier than FTW-daily v9, FTW-hourly
+v11 or FTW-product v10), you might have this file in your codebase. If
+you start using sharetribe-scripts v6.0.0, you need to consider
+migrating away from that since it contains code that is deprecated in
+v6.0.0 of sharetribe-scripts.
 
-Read more from [this pull request](https://github.com/sharetribe/ftw-daily/pull/1531) in FTW-Daily.
+Read more from
+[this pull request](https://github.com/sharetribe/ftw-daily/pull/1531)
+in FTW-Daily.
 
 </extrainfo>
 
@@ -56,12 +63,14 @@ Read more from [this pull request](https://github.com/sharetribe/ftw-daily/pull/
         └── marketplaceDefaults.css
 ```
 
-We have created marketplace-level styling variables with [CSS Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
+We have created marketplace-level styling variables with
+[CSS Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
 (vars) and a few global CSS classes.
 
-The concept behind [CSS Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) is quite straightforward - they are
-variables that can be defined in root-element level (`<html>`) and then
-used inside some CSS rule.
+The concept behind
+[CSS Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
+is quite straightforward - they are variables that can be defined in
+root-element level (`<html>`) and then used inside some CSS rule.
 
 ```css
 /* in src/styles/marketplaceDefaults.css */
@@ -112,7 +121,9 @@ On a live site, the CSS file contains:
 ### marketplaceDefaults.css
 
 This is a good place to start customizing marketplace styles. For
-example, we define our color scheme here using [CSS Property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) variables:
+example, we define our color scheme here using
+[CSS Property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
+variables:
 
 ```css
 /* ================ Colors ================ */
@@ -251,7 +262,8 @@ p {
 ## Fonts
 
 **marketplaceDefaults.css** file is mostly responsible of what font
-styles are used. The font-family itself is defined in the [CSS Property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
+styles are used. The font-family itself is defined in the
+[CSS Property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
 `--fontFamily` and by default, FTW templates use Poppins. This is a
 Google Font, but for performance reasons we have served them from
 Sharetribe's CDN.
@@ -364,8 +376,10 @@ Some guidelines we have tried to follow:
 
 - **Use semantic class names**<br/> They improve readability and
   decouples style changes from DOM changes.
-- **Use the [CSS Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) defined in marketplaceDefaults.css**<br/> and
-  create new ones when it makes sense.
+- **Use the
+  [CSS Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
+  defined in marketplaceDefaults.css**<br/> and create new ones when it
+  makes sense.
 - **Use classes**, don't style DOM elements directly.<br/> Element
   styles are global even with CSS Modules.
 - **Avoid nesting styles**.<br/> CSS Modules makes specificity rules

--- a/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
+++ b/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
@@ -1,7 +1,7 @@
 ---
 title: How to customize FTW styles
 slug: how-to-customize-ftw-styles
-updated: 2021-02-12
+updated: 2022-07-11
 category: ftw-styling
 ingress:
   This guide describes how to change the styles of the Flex Template for
@@ -18,27 +18,49 @@ template application:
 
 - [Marketplace level styling](#marketplace-level-styling) with 3 global
   stylesheets:
-  - _src/styles/**marketplaceDefaults.css**_ (contains CSS variables and
-    element styles)
+  - _src/styles/**marketplaceDefaults.css**_ (contains CSS variables,
+    element styles, and global CSS classes)
   - _src/styles/**customMediaQueries.css**_ (contains breakpoints for
     responsive layout)
-  - _src/styles/**propertySets.css**_ (contains CSS Property Sets aka
-    @apply rules)
 - [Component level styling](#styling-components) using
   [CSS Modules](https://github.com/css-modules/css-modules)
+
+<extrainfo title="I have a propertySets.css file. What is that?">
+
+```shell
+└── src
+    └── styles
+        └── propertySets.css
+```
+
+In the previous versions of FTW templates, there has been also a third
+file: propertySets.css. This file contained CSS Property Sets that could
+be applied to component styles with `@apply` syntax. However, W3C
+decided not to include that feature in future CSS syntax and the
+postcss-apply plugin was deprecated in the process.
+
+So, if you have an older FTW template (earlier than FTW-daily v9,
+FTW-hourly v11, or FTW-product v10), you might have this file in your
+codebase. If you start using sharetribe-scripts v6.0.0 you need to
+consider migrating away from that since it contains code that is
+deprecated in v6.0.0 of sharetribe-scripts.
+
+Read more from the pull request in FTW-daily:
+https://github.com/sharetribe/ftw-daily/pull/1531
+
+</extrainfo>
 
 ## Marketplace level styling
 
 ```shell
 └── src
     └── styles
-        ├── propertySets.css
         ├── customMediaQueries.css
         └── marketplaceDefaults.css
 ```
 
 We have created marketplace-level styling variables with CSS Properties
-(vars) and CSS Property Sets (@apply rules).
+(vars) and a few global CSS classes.
 
 The concept behind CSS Properties is quite straightforward - they are
 variables that can be defined in root-element level (`<html>`) and then
@@ -60,6 +82,35 @@ used inside some CSS rule.
 
 (Read more about CSS Properties from
 [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties))
+
+### customMediaQueries.css
+
+Breakpoints for media queries are defined in separate file.
+
+```css
+@custom-media --viewportSmall (min-width: 550px);
+@custom-media --viewportMedium (min-width: 768px);
+@custom-media --viewportLarge (min-width: 1024px);
+// etc.
+```
+
+These custom media query breakpoints can be used in a similar way as CSS
+Properties. However, these variable are converted to real media queries
+on build-time.
+
+```css
+@media (--viewportMedium) {
+  /* CSS classes */
+}
+```
+
+On a live site, the CSS file contains:
+
+```css
+@media (min-width: 768px) {
+  /* CSS classes */
+}
+```
 
 ### marketplaceDefaults.css
 
@@ -115,43 +166,60 @@ so on. Our current plan is to parameterize styling even more using this
 concept.
 
 In addition, this file provides default styles for plain elements like
-`<body>`, `<a>`, `<p>`, `<input>`, `<h1>`, `<h2>`, and so on.
+`<body>`, `<a>`, `<p>`, `<input>`, `<h1>`, `<h2>`, and so on. There are
+also some global CSS classes that components can use.
 
-### customMediaQueries.css
+### Global CSS classes
 
-Breakpoints for media queries are defined in separate file.
-
-```css
-@custom-media --viewportSmall (min-width: 550px);
-@custom-media --viewportMedium (min-width: 768px);
-@custom-media --viewportLarge (min-width: 1024px);
-// etc.
-```
-
-These custom media query breakpoints can be used in a similar way as CSS
-Properties. However, these variable are converted to real media queries
-on build-time.
-
-```css
-@media (--viewportMedium) {
-  /* CSS classes */
-}
-```
-
-On a live site, the CSS file contains:
-
-```css
-@media (min-width: 768px) {
-  /* CSS classes */
-}
-```
-
-### propertySets.css
-
-Fonts are specified in this files using CSS Property Sets. They provide
-us a solid way of creating a fixed set of CSS rules for a specific font.
+Fonts and some other shared styles are specified in
+customMediaQueries.css file using global (vanilla) CSS classes. They
+provide us a way to share some generic styles between components.
 
 For example, our default font is defined as:
+
+```css
+.marketplaceDefaultFontStyles {
+  font-family: var(--fontFamily);
+  font-weight: var(--fontWeightMedium);
+  font-size: 14px;
+  line-height: 24px;
+  letter-spacing: -0.1px;
+  /* No margins for default font */
+
+  @media (--viewportMedium) {
+    font-size: 16px;
+    line-height: 32px;
+  }
+}
+```
+
+And created class can be used inside a component's
+[CSS Module syntax](#styling-components) as:
+
+```css
+.tip {
+  composes: marketplaceDefaultFontStyles from global;
+}
+```
+
+<extrainfo title="I don't have classes in customMediaQueries.css but I have a propertySets.css file. What is that?">
+
+In the previous versions of FTW templates, there has been also a third
+file: propertySets.css. This file contained CSS Property Sets that could
+be applied to component styles with `@apply` syntax. However, W3C
+decided not to include that feature in future CSS syntax and the
+postcss-apply plugin was deprecated in the process.
+
+So, if you have an older FTW template (earlier than FTW-daily v9,
+FTW-hourly v11, or FTW-product v10), you might have this file in your
+codebase. If you start using sharetribe-scripts v6.0.0 you need to
+consider migrating away from that since it contains code that is
+deprecated in v6.0.0 of sharetribe-scripts.
+
+Previously, fonts and other shared sets of CSS rules were specified in
+propertySets.css.
+
+For example, our default font was defined as:
 
 ```css
 --marketplaceDefaultFontStyles: {
@@ -169,7 +237,7 @@ For example, our default font is defined as:
 }
 ```
 
-And created property set can be used as:
+And created property set were used as:
 
 ```css
 p {
@@ -177,21 +245,19 @@ p {
 }
 ```
 
+</extrainfo>
+
 > ⚠️ **Note**: template app is following a pattern where the height of
 > an element should be divisible by **6px** on mobile layout and **8px**
 > on bigger layouts. This affects line-heights of font styles too.
 
-> ⚠️ **Note**: the **@apply** rule and custom property sets most likely
-> won't get any more support from browser vendors as the spec is yet
-> considered deprecated and alternative solutions are being discussed.
-
 ## Fonts
 
-**marketplaceDefaults.css** and **propertySets.css** files are mostly
-responsible of what font styles are used. The font-family itself is
-defined in CSS Property `--fontFamily` and by default, FTW templates use
-Poppins. This is a Google Font, but for performance reasons we have
-served them from Sharetribe's CDN.
+**marketplaceDefaults.css** file is mostly responsible of what font
+styles are used. The font-family itself is defined in CSS Property
+`--fontFamily` and by default, FTW templates use Poppins. This is a
+Google Font, but for performance reasons we have served them from
+Sharetribe's CDN.
 
 The actual font files are loaded in _public/index.html_. If you want to
 change the font or loading strategy, you need to edit those 3 files. To
@@ -311,9 +377,10 @@ Some guidelines we have tried to follow:
   improves readability.
 - **Parent component is responsible for allocating space** for a child
   component (i.e. dimensions and margins).
-- **Define `@apply` rules early enough** inside declaration block.<br/>
-  Rules inside those property sets might overwrite rules written above
-  the line where the set is applied.
+- **Define `composes` declarations early enough** inside the declaration
+  block.<br/> Be careful: rules inside those global CSS declarations
+  might overwrite rules written inside the component's own class. This
+  depends on the specificity given in the global (vanilla) CSS file.
 - **Align text and components** to horizontal baselines. I.e. they
   should be a multiple of **_6px_** on mobile layout and **_8px_** on
   bigger screens.

--- a/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
+++ b/src/docs/ftw-styling/how-to-customize-ftw-styles/index.md
@@ -33,20 +33,17 @@ template application:
         └── propertySets.css
 ```
 
-In the previous versions of FTW templates, there has been also a third
-file: propertySets.css. This file contained CSS Property Sets that could
-be applied to component styles with `@apply` syntax. However, W3C
-decided not to include that feature in future CSS syntax and the
-postcss-apply plugin was deprecated in the process.
+In previous versions of FTW, there has been a third CSS
+file: propertySets.css. This file contains [CSS Property Sets](https://chromestatus.com/feature/5753701012602880) that can be applied to component styles using the `@apply`syntax.
+However, W3C decided not to include that feature in future CSS syntax, and the [postcss-apply plugin](https://github.com/pascalduez/postcss-apply) got deprecated in the process.
 
-So, if you have an older FTW template (earlier than FTW-daily v9,
-FTW-hourly v11, or FTW-product v10), you might have this file in your
-codebase. If you start using sharetribe-scripts v6.0.0 you need to
+If you have an older FTW template (earlier than FTW-daily v9,
+FTW-hourly v11 or FTW-product v10), you might have this file in your
+codebase. If you start using sharetribe-scripts v6.0.0, you need to
 consider migrating away from that since it contains code that is
 deprecated in v6.0.0 of sharetribe-scripts.
 
-Read more from the pull request in FTW-daily:
-https://github.com/sharetribe/ftw-daily/pull/1531
+Read more from [this pull request](https://github.com/sharetribe/ftw-daily/pull/1531) in FTW-Daily.
 
 </extrainfo>
 
@@ -59,10 +56,10 @@ https://github.com/sharetribe/ftw-daily/pull/1531
         └── marketplaceDefaults.css
 ```
 
-We have created marketplace-level styling variables with CSS Properties
+We have created marketplace-level styling variables with [CSS Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
 (vars) and a few global CSS classes.
 
-The concept behind CSS Properties is quite straightforward - they are
+The concept behind [CSS Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) is quite straightforward - they are
 variables that can be defined in root-element level (`<html>`) and then
 used inside some CSS rule.
 
@@ -85,7 +82,7 @@ used inside some CSS rule.
 
 ### customMediaQueries.css
 
-Breakpoints for media queries are defined in separate file.
+Breakpoints for media queries are defined in customMediaQueries.css.
 
 ```css
 @custom-media --viewportSmall (min-width: 550px);
@@ -95,8 +92,8 @@ Breakpoints for media queries are defined in separate file.
 ```
 
 These custom media query breakpoints can be used in a similar way as CSS
-Properties. However, these variable are converted to real media queries
-on build-time.
+Properties. However, these variables are converted to real media queries
+during build-time.
 
 ```css
 @media (--viewportMedium) {
@@ -115,7 +112,7 @@ On a live site, the CSS file contains:
 ### marketplaceDefaults.css
 
 This is a good place to start customizing marketplace styles. For
-example, we define our color scheme here using CSS Property variables:
+example, we define our color scheme here using [CSS Property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) variables:
 
 ```css
 /* ================ Colors ================ */
@@ -171,8 +168,8 @@ also some global CSS classes that components can use.
 
 ### Global CSS classes
 
-Fonts and some other shared styles are specified in
-customMediaQueries.css file using global (vanilla) CSS classes. They
+Fonts and some other shared styles are specified in the
+marketplaceDefaults.css file using global (vanilla) CSS classes. They
 provide us a way to share some generic styles between components.
 
 For example, our default font is defined as:
@@ -254,7 +251,7 @@ p {
 ## Fonts
 
 **marketplaceDefaults.css** file is mostly responsible of what font
-styles are used. The font-family itself is defined in CSS Property
+styles are used. The font-family itself is defined in the [CSS Property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
 `--fontFamily` and by default, FTW templates use Poppins. This is a
 Google Font, but for performance reasons we have served them from
 Sharetribe's CDN.
@@ -367,7 +364,7 @@ Some guidelines we have tried to follow:
 
 - **Use semantic class names**<br/> They improve readability and
   decouples style changes from DOM changes.
-- **Use CSS Properties defined in marketplaceDefaults.css**<br/> and
+- **Use the [CSS Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) defined in marketplaceDefaults.css**<br/> and
   create new ones when it makes sense.
 - **Use classes**, don't style DOM elements directly.<br/> Element
   styles are global even with CSS Modules.

--- a/src/docs/howto-users-and-authentication/implement-delete-user/cookbook-assets/DeleteAccountForm.module.css
+++ b/src/docs/howto-users-and-authentication/implement-delete-user/cookbook-assets/DeleteAccountForm.module.css
@@ -1,4 +1,6 @@
-@import '../../styles/propertySets.css';
+@import '../../styles/customMediaQueries.css';
+/* Older versions of template should import deprecated file: */
+/* @import '../../styles/propertySets.css'; */
 
 .root {
 }
@@ -60,7 +62,9 @@
 }
 
 .error {
-  @apply --marketplaceH4FontStyles;
+  /* Older versions of template should use '@apply' instead of 'composes' */
+  /* @apply --marketplaceH4FontStyles; */
+  composes: h4 from global;
   color: var(--failColor);
   text-align: center;
   display: inline-block;
@@ -73,7 +77,9 @@
 }
 
 .helperLink {
-  @apply --marketplaceLinkStyles;
+  /* Older versions of template should use '@apply' instead of 'composes' */
+  /* @apply --marketplaceLinkStyles; */
+  composes: marketplaceLinkStyles from global;
   color: var(--matterColor);
   font-weight: var(--fontWeightMedium);
   text-decoration: underline;

--- a/src/docs/introduction/getting-started-with-ftw-daily/index.md
+++ b/src/docs/introduction/getting-started-with-ftw-daily/index.md
@@ -118,7 +118,7 @@ basic development tooling:
    │   ├── forms
    │   ├── styles
    │   │   ├── marketplaceDefaults.css
-   │   │   └── propertySets.css
+   │   │   └── customMediaQueries.css
    │   ├── translations
    │   ├── util
    │   ├── Routes.js

--- a/src/docs/references/events/index.md
+++ b/src/docs/references/events/index.md
@@ -28,7 +28,8 @@ solving use cases such as synchronizing changes in marketplace data into
 external places, e.g. a CRM, a spreadsheet or a calendar. It also allows
 programs to react to logical actions as part of the marketplace flows.
 For example, setting a field in user metadata can trigger an integration
-to publish the user's listings. Using events makes it possible to cover many of the use cases where other applications use webhooks.
+to publish the user's listings. Using events makes it possible to cover
+many of the use cases where other applications use webhooks.
 
 Currently, Flex exposes events by allowing them to be queried via the
 [Integration API](https://www.sharetribe.com/api-reference/integration.html#query-events)

--- a/src/docs/tutorial-branding/change-image-assets/index.md
+++ b/src/docs/tutorial-branding/change-image-assets/index.md
@@ -87,20 +87,18 @@ There you might find something like:
 }
 ```
 
-In the previous versions of FTW templates, there has been also a third
-file: propertySets.css. This file contained CSS Property Sets that could
-be applied to component styles with `@apply` syntax. However, W3C
-decided not to include that feature in future CSS syntax and the
-postcss-apply plugin was deprecated in the process.
+In previous versions of FTW, there has been a third CSS
+file: propertySets.css. This file contains [CSS Property Sets](https://chromestatus.com/feature/5753701012602880) that can be applied to component styles using the `@apply`syntax.
+However, W3C decided not to include that feature in future CSS syntax, and the [postcss-apply plugin](https://github.com/pascalduez/postcss-apply) got deprecated in the process.
 
-So, if you have an older FTW template (earlier than FTW-daily v9,
-FTW-hourly v11, or FTW-product v10), you might have this file in your
-codebase. If you start using sharetribe-scripts v6.0.0 you need to
+If you have an older FTW template (earlier than FTW-daily v9,
+FTW-hourly v11 or FTW-product v10), you might have this file in your
+codebase. If you start using sharetribe-scripts v6.0.0, you need to
 consider migrating away from that since it contains code that is
 deprecated in v6.0.0 of sharetribe-scripts.
 
-Read more from the pull request in FTW-daily:
-https://github.com/sharetribe/ftw-daily/pull/1531
+Read more from [this pull request](https://github.com/sharetribe/ftw-daily/pull/1531) in FTW-Daily.
+
 
 </extrainfo>
 

--- a/src/docs/tutorial-branding/change-image-assets/index.md
+++ b/src/docs/tutorial-branding/change-image-assets/index.md
@@ -1,7 +1,7 @@
 ---
 title: Change image assets
 slug: change-image-assets
-updated: 2020-02-28
+updated: 2022-07-11
 category: tutorial-branding
 ingress:
   Learn how to update image assets such as the default background image,
@@ -12,17 +12,54 @@ published: true
 ## Default background image
 
 In the [previous step](/tutorial/first-edit/), you made changes to the
-marketplaceDefaults.css file. This time you make changes to
-propertySets.css. **`--backgroundImage`** variable can be found from
-there. It is used to provide a background image for Hero component on
-the landing page as well as some of the other pages: sing-up and log-in,
-email verification etc.
+CSS Properties on marketplaceDefaults.css file. This time you make
+changes to global CSS classes. **`.defaultBackgroundImage`** class can
+be found from there too. It is used to provide a background image for
+the Hero component on the landing page.
+
+```shell
+└── src
+    └── styles
+        └── marketplaceDefaults.css
+```
+
+```css
+/* ================ Plain global CSS glasses ================ */
+
+/* Full screen Background image located in root-folder/src/assets */
+.defaultBackgroundImage {
+  /* Gradient direction and overlaying the black color on top of the image for better readability */
+  background: linear-gradient(
+      -45deg,
+      rgba(0, 0, 0, 0.3),
+      rgba(0, 0, 0, 0.6)
+    ), url('../assets/background-1440.jpg');
+
+  /* Add loading color for the div */
+  background-color: var(--matterColor);
+
+  /* Cover the whole screen with the background image */
+  background-size: cover;
+
+  /* Align the image within the container */
+  background-position: center center;
+
+  @media (--viewportLarge) {
+    border-radius: 40px;
+    border: solid 36px var(--matterColorBright);
+  }
+}
+```
+
+<extrainfo title="I can't find it, but I have something similar in a file called propertySets.css. What is that?">
 
 ```shell
 └── src
     └── styles
         └── propertySets.css
 ```
+
+There you might find something like:
 
 ```css
 /* Full screen Background image located in root-folder/src/assets */
@@ -50,6 +87,23 @@ email verification etc.
 }
 ```
 
+In the previous versions of FTW templates, there has been also a third
+file: propertySets.css. This file contained CSS Property Sets that could
+be applied to component styles with `@apply` syntax. However, W3C
+decided not to include that feature in future CSS syntax and the
+postcss-apply plugin was deprecated in the process.
+
+So, if you have an older FTW template (earlier than FTW-daily v9,
+FTW-hourly v11, or FTW-product v10), you might have this file in your
+codebase. If you start using sharetribe-scripts v6.0.0 you need to
+consider migrating away from that since it contains code that is
+deprecated in v6.0.0 of sharetribe-scripts.
+
+Read more from the pull request in FTW-daily:
+https://github.com/sharetribe/ftw-daily/pull/1531
+
+</extrainfo>
+
 That **background** styling-rule refers to _background-1440.jpg_ image
 in the _assets_ directory:
 
@@ -61,9 +115,9 @@ in the _assets_ directory:
 
 So, to change it, we could just save a different image as
 'background-1440.jpg' to replace the default background image (or you
-can add a new image and then change the filename in `--backgroundImage`
-property set). The image should be 1440 pixels wide so that it doesn't
-look bad on retina displays.
+can add a new image and then change the filename in
+`.defaultBackgroundImage` class). The image should be 1440 pixels wide
+so that it doesn't look bad on retina displays.
 
 Here's an image, we used in this tutorial:<br />
 [Summer house by Markus Spiske (cropped)](/tutorial-assets/markus-spiske-summer-house-unsplash.jpg)

--- a/src/docs/tutorial-branding/change-image-assets/index.md
+++ b/src/docs/tutorial-branding/change-image-assets/index.md
@@ -87,18 +87,24 @@ There you might find something like:
 }
 ```
 
-In previous versions of FTW, there has been a third CSS
-file: propertySets.css. This file contains [CSS Property Sets](https://chromestatus.com/feature/5753701012602880) that can be applied to component styles using the `@apply`syntax.
-However, W3C decided not to include that feature in future CSS syntax, and the [postcss-apply plugin](https://github.com/pascalduez/postcss-apply) got deprecated in the process.
+In previous versions of FTW, there has been a third CSS file:
+propertySets.css. This file contains
+[CSS Property Sets](https://chromestatus.com/feature/5753701012602880)
+that can be applied to component styles using the `@apply`syntax.
+However, W3C decided not to include that feature in future CSS syntax,
+and the
+[postcss-apply plugin](https://github.com/pascalduez/postcss-apply) got
+deprecated in the process.
 
-If you have an older FTW template (earlier than FTW-daily v9,
-FTW-hourly v11 or FTW-product v10), you might have this file in your
-codebase. If you start using sharetribe-scripts v6.0.0, you need to
-consider migrating away from that since it contains code that is
-deprecated in v6.0.0 of sharetribe-scripts.
+If you have an older FTW template (earlier than FTW-daily v9, FTW-hourly
+v11 or FTW-product v10), you might have this file in your codebase. If
+you start using sharetribe-scripts v6.0.0, you need to consider
+migrating away from that since it contains code that is deprecated in
+v6.0.0 of sharetribe-scripts.
 
-Read more from [this pull request](https://github.com/sharetribe/ftw-daily/pull/1531) in FTW-Daily.
-
+Read more from
+[this pull request](https://github.com/sharetribe/ftw-daily/pull/1531)
+in FTW-Daily.
 
 </extrainfo>
 

--- a/src/docs/tutorial-branding/first-edit/index.md
+++ b/src/docs/tutorial-branding/first-edit/index.md
@@ -33,20 +33,18 @@ Properties, element styles, and global css classes):
         └── propertySets.css
 ```
 
-In the previous versions of FTW templates, there has been also a third
-file: propertySets.css. This file contained CSS Property Sets that could
-be applied to component styles with `@apply` syntax. However, W3C
-decided not to include that feature in future CSS syntax and the
-postcss-apply plugin was deprecated in the process.
+In previous versions of FTW, there has been a third CSS
+file: propertySets.css. This file contains [CSS Property Sets](https://chromestatus.com/feature/5753701012602880) that can be applied to component styles using the `@apply`syntax.
+However, W3C decided not to include that feature in future CSS syntax, and the [postcss-apply plugin](https://github.com/pascalduez/postcss-apply) got deprecated in the process.
 
-So, if you have an older FTW template (earlier than FTW-daily v9,
-FTW-hourly v11, or FTW-product v10), you might have this file in your
-codebase. If you start using sharetribe-scripts v6.0.0 you need to
+If you have an older FTW template (earlier than FTW-daily v9,
+FTW-hourly v11 or FTW-product v10), you might have this file in your
+codebase. If you start using sharetribe-scripts v6.0.0, you need to
 consider migrating away from that since it contains code that is
 deprecated in v6.0.0 of sharetribe-scripts.
 
-Read more from the pull request in FTW-daily:
-https://github.com/sharetribe/ftw-daily/pull/1531
+Read more from [this pull request](https://github.com/sharetribe/ftw-daily/pull/1531) in FTW-Daily.
+
 
 </extrainfo>
 

--- a/src/docs/tutorial-branding/first-edit/index.md
+++ b/src/docs/tutorial-branding/first-edit/index.md
@@ -33,18 +33,24 @@ Properties, element styles, and global css classes):
         └── propertySets.css
 ```
 
-In previous versions of FTW, there has been a third CSS
-file: propertySets.css. This file contains [CSS Property Sets](https://chromestatus.com/feature/5753701012602880) that can be applied to component styles using the `@apply`syntax.
-However, W3C decided not to include that feature in future CSS syntax, and the [postcss-apply plugin](https://github.com/pascalduez/postcss-apply) got deprecated in the process.
+In previous versions of FTW, there has been a third CSS file:
+propertySets.css. This file contains
+[CSS Property Sets](https://chromestatus.com/feature/5753701012602880)
+that can be applied to component styles using the `@apply`syntax.
+However, W3C decided not to include that feature in future CSS syntax,
+and the
+[postcss-apply plugin](https://github.com/pascalduez/postcss-apply) got
+deprecated in the process.
 
-If you have an older FTW template (earlier than FTW-daily v9,
-FTW-hourly v11 or FTW-product v10), you might have this file in your
-codebase. If you start using sharetribe-scripts v6.0.0, you need to
-consider migrating away from that since it contains code that is
-deprecated in v6.0.0 of sharetribe-scripts.
+If you have an older FTW template (earlier than FTW-daily v9, FTW-hourly
+v11 or FTW-product v10), you might have this file in your codebase. If
+you start using sharetribe-scripts v6.0.0, you need to consider
+migrating away from that since it contains code that is deprecated in
+v6.0.0 of sharetribe-scripts.
 
-Read more from [this pull request](https://github.com/sharetribe/ftw-daily/pull/1531) in FTW-Daily.
-
+Read more from
+[this pull request](https://github.com/sharetribe/ftw-daily/pull/1531)
+in FTW-Daily.
 
 </extrainfo>
 

--- a/src/docs/tutorial-branding/first-edit/index.md
+++ b/src/docs/tutorial-branding/first-edit/index.md
@@ -1,7 +1,7 @@
 ---
 title: First customization
 slug: first-edit
-updated: 2021-02-12
+updated: 2022-07-11
 category: tutorial-branding
 ingress:
   Begin customizing your marketplace by custom styling and introducing
@@ -15,16 +15,40 @@ Custom styling is a good starting point to introduce your own branding
 and remove design choices made for example marketplace, Saunatime.
 
 FTW templates have most of the styling tied to component directories,
-but there are 3 files that define custom media queries, default CSS
-Properties, and property sets:
+but there are 2 files that define custom media queries, default CSS (CSS
+Properties, element styles, and global css classes):
 
 ```shell
 └── src
     └── styles
-        ├── propertySets.css
         ├── customMediaQueries.css
         └── marketplaceDefaults.css
 ```
+
+<extrainfo title="I have a propertySets.css file. What is that?">
+
+```shell
+└── src
+    └── styles
+        └── propertySets.css
+```
+
+In the previous versions of FTW templates, there has been also a third
+file: propertySets.css. This file contained CSS Property Sets that could
+be applied to component styles with `@apply` syntax. However, W3C
+decided not to include that feature in future CSS syntax and the
+postcss-apply plugin was deprecated in the process.
+
+So, if you have an older FTW template (earlier than FTW-daily v9,
+FTW-hourly v11, or FTW-product v10), you might have this file in your
+codebase. If you start using sharetribe-scripts v6.0.0 you need to
+consider migrating away from that since it contains code that is
+deprecated in v6.0.0 of sharetribe-scripts.
+
+Read more from the pull request in FTW-daily:
+https://github.com/sharetribe/ftw-daily/pull/1531
+
+</extrainfo>
 
 ## Changing CSS variables
 

--- a/src/pages/concepts.js
+++ b/src/pages/concepts.js
@@ -81,9 +81,7 @@ const ConceptsPage = () => {
             }
           }, [])
           .sort(byArrayOfSlugs(sortingArray));
-        return (
-          <ArticleIndexPage category={category} articles={articles} />
-        );
+        return <ArticleIndexPage category={category} articles={articles} />;
       }}
     />
   );

--- a/src/pages/design-toolkit.js
+++ b/src/pages/design-toolkit.js
@@ -64,9 +64,7 @@ const DesignToolkitPage = () => {
             }
           }, [])
           .sort(byArrayOfSlugs(sortingArray));
-        return (
-          <ArticleIndexPage category={category} articles={articles} />
-        );
+        return <ArticleIndexPage category={category} articles={articles} />;
       }}
     />
   );

--- a/src/pages/ftw.js
+++ b/src/pages/ftw.js
@@ -85,9 +85,7 @@ const FTWPage = () => {
             }
           }, [])
           .sort(byArrayOfSlugs(sortingArray));
-        return (
-          <ArticleIndexPage category={category} articles={articles} />
-        );
+        return <ArticleIndexPage category={category} articles={articles} />;
       }}
     />
   );

--- a/src/pages/how-to.js
+++ b/src/pages/how-to.js
@@ -82,9 +82,7 @@ const HowtoPage = () => {
             }
           }, [])
           .sort(byArrayOfSlugs(sortingArray));
-        return (
-          <ArticleIndexPage category={category} articles={articles} />
-        );
+        return <ArticleIndexPage category={category} articles={articles} />;
       }}
     />
   );

--- a/src/pages/introduction.js
+++ b/src/pages/introduction.js
@@ -74,9 +74,7 @@ const IntroductionPage = () => {
             }
           }, [])
           .sort(byArrayOfSlugs(sortingArray));
-        return (
-          <ArticleIndexPage category={category} articles={articles} />
-        );
+        return <ArticleIndexPage category={category} articles={articles} />;
       }}
     />
   );

--- a/src/pages/operator-guides.js
+++ b/src/pages/operator-guides.js
@@ -65,9 +65,7 @@ const OperatorGuidesPage = () => {
         }, []);
         // TODO .sort(byArrayOfSlugs(sortingArray));
 
-        return (
-          <ArticleIndexPage category={category} articles={articles} />
-        );
+        return <ArticleIndexPage category={category} articles={articles} />;
       }}
     />
   );

--- a/src/pages/references.js
+++ b/src/pages/references.js
@@ -65,9 +65,7 @@ const ReferencesPage = () => {
           }, [])
           .sort(byArrayOfSlugs(sortingArray));
 
-        return (
-          <ArticleIndexPage category={category} articles={articles} />
-        );
+        return <ArticleIndexPage category={category} articles={articles} />;
       }}
     />
   );

--- a/src/pages/tutorial.js
+++ b/src/pages/tutorial.js
@@ -75,9 +75,7 @@ const TutorialPage = () => {
             }
           }, [])
           .sort(byArrayOfSlugs(sortingArray));
-        return (
-          <ArticleIndexPage category={category} articles={articles} />
-        );
+        return <ArticleIndexPage category={category} articles={articles} />;
       }}
     />
   );


### PR DESCRIPTION
propertySets.css will be removed from templates. This updates all the docs that mention it.

In addition, I called `yarn run format`.