### PR TITLE
Open external links in new tab

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -119,6 +119,12 @@ module.exports = {
               noInlineHighlight: true,
             },
           },
+          {
+            resolve: 'gatsby-remark-external-links',
+            options: {
+              rel: 'noopener noreferrer',
+            },
+          },
         ],
       },
     },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gatsby-plugin-styled-components": "^5.6.0",
     "gatsby-remark-autolink-headers": "^5.6.0",
     "gatsby-remark-copy-linked-files": "^5.10.0",
+    "gatsby-remark-external-links": "^0.0.4",
     "gatsby-remark-images": "^6.6.0",
     "gatsby-remark-prismjs": "^6.6.0",
     "gatsby-source-filesystem": "^4.6.0",
@@ -55,8 +56,8 @@
     "styled-components": "^5.3.3"
   },
   "devDependencies": {
+    "husky": "^8.0.0",
     "lint-staged": "^13.0.3",
-    "prettier": "^1.19.1",
-    "husky": "^8.0.0"
+    "prettier": "^1.19.1"
   }
 }

--- a/src/docs/concepts-availability/inventory-management/index.md
+++ b/src/docs/concepts-availability/inventory-management/index.md
@@ -1,7 +1,7 @@
 ---
 title: Inventory management
 slug: inventory-management
-updated: 2021-10-15
+updated: 2022-08-18
 category: concepts-availability
 ingress:
   Inventory or stock management is a key feature of many product
@@ -19,19 +19,19 @@ mostly happen as part of transactions, as buyers on your marketplace
 make purchases.
 
 This article describes the stock management features of Flex on a high
-level. If you want to read a more technical article about the feature,
-[click here](https://www.sharetribe.com/docs/references/stock/).
+level. We also have
+[a more technical article about stock management](/references/stock/).
 
 ## How do you determine the initial available stock or increase the available stock of a listing?
 
 With the stock-related APIs, you add to the available stock of a listing
 by creating a
-[stock adjustment](https://www.sharetribe.com/docs/operator-guides/concepts/#stock-adjustment).
-This is an API call that you make through one of our APIs that lets your
-Flex marketplace know that you have increased the quantity of available
-stock for one of your listings. This adjustment could be done directly
-through the marketplace UI or a third-party integration using the
-corresponding API calls.
+[stock adjustment](/operator-guides/concepts/#stock-adjustment). This is
+an API call that you make through one of our APIs that lets your Flex
+marketplace know that you have increased the quantity of available stock
+for one of your listings. This adjustment could be done directly through
+the marketplace UI or a third-party integration using the corresponding
+API calls.
 
 ## How do you remove or decrease the available stock of a listing?
 
@@ -45,8 +45,8 @@ available.
 If the transaction completes, the purchased units are removed from the
 inventory permanently. If the transaction is cancelled, the units are
 released back to the inventory and other users will be able to purchase
-them. Find out more about transactions actions
-[here](https://www.sharetribe.com/docs/references/transaction-process-actions/#stock-reservations).
+them. Find out more about
+[transaction process actions related to stock reservations](/references/transaction-process-actions/#stock-reservations).
 
 You can also connect your Flex marketplace with third-party systems to
 further manage stock. If units are bought through another site or
@@ -70,5 +70,4 @@ double-purchases of the same stock will happen.
 If you are looking to manage the number of spaces in an event, you
 should take a look at the seats feature. With seats, you can manage the
 number of available spaces in a given event at a given time. Seats are
-tied to booking availability managment. You can learn more about the
-feature [here](https://www.sharetribe.com/docs/concepts/manage-seats/).
+tied to [booking availability management](/concepts/manage-seats/).

--- a/src/docs/concepts-availability/manage-seats/index.md
+++ b/src/docs/concepts-availability/manage-seats/index.md
@@ -31,7 +31,7 @@ or
 
 You define the available seats for any given time slot of a listing via
 the
-[availability plan or availability exceptions](https://www.sharetribe.com/docs/operator-guides/concepts/#availability-plan--availability-exception)
+[availability plan or availability exceptions](/operator-guides/concepts/#availability-plan--availability-exception)
 of a listing. If the number of seats is set to 0, the listing will not
 be available at that time.
 
@@ -58,7 +58,7 @@ Some examples:
 
 Most of the time, a listing's available seats will decrease through
 bookings via transactions. The
-[booking-related transaction process actions](https://www.sharetribe.com/docs/references/transaction-process-actions/#bookings)
+[booking-related transaction process actions](/references/transaction-process-actions/#bookings)
 allow defining your transaction process so that when a transaction is
 initiated, a seat reservation is made as well. This prevents your users
 from booking more seats than are available.
@@ -66,8 +66,8 @@ from booking more seats than are available.
 If the transaction completes, the seats are removed from the listing’s
 or timeslot’s availability. If the transaction is cancelled, the seats
 are released and other users will be able to book them. Find out more
-about transactions actions
-[here](https://www.sharetribe.com/docs/references/transaction-process-actions/#bookings).
+about
+[availability related transaction actions](/references/transaction-process-actions/#bookings).
 
 You can also connect your Flex marketplace with third-party systems to
 further manage seats. If bookings are made through another system, you
@@ -100,6 +100,5 @@ same timeframe.
 ## Can I manage stock or inventory of a listing with seats?
 
 If you are looking to manage the stock or inventory of a listing, you
-should take a look at Flex’s stock management. You can learn more about
-the feature
-[here](https://www.sharetribe.com/docs/concepts/inventory-management/).
+should take a look at
+[stock management in Flex](/concepts/inventory-management/).

--- a/src/docs/concepts-development/console-overview/index.md
+++ b/src/docs/concepts-development/console-overview/index.md
@@ -80,8 +80,8 @@ delete users or listings, ban users, and edit default listing and user
 information. You can also export all this information into a CSV file to
 use as you see fit. Perhaps most important of all, you can add and
 modify the extended data of your marketplace elements in the Manage
-section. You can read more about extended data
-[in this article](https://www.sharetribe.com/docs/concepts/extended-data-introduction/).
+section. You can
+[read more about extended data](/concepts/extended-data-introduction/).
 
 ### Build
 
@@ -107,7 +107,7 @@ different kinds of transaction processes your marketplace has. You can
 toggle between the different processes in the left-side selection and
 see how many transactions have used each process. You can also inspect
 the components of the transaction processes. Read more about
-[transaction processes in Flex](https://www.sharetribe.com/docs/concepts/transaction-process/).
+[transaction processes in Flex](/concepts/transaction-process/).
 
 **Payments** has information about your Stripe configuration. Your
 Stripe secret key is added here. The public key is configured within the

--- a/src/docs/concepts-development/flex-environments/index.md
+++ b/src/docs/concepts-development/flex-environments/index.md
@@ -51,7 +51,7 @@ the activity in Console.
 Development environment is for development and testing purposes. This is
 where building your marketplace happens and where you can test the build
 functionalities in peace by using test users and
-[test credit cards with Stripe](https://www.sharetribe.com/docs/how-to/set-up-and-use-stripe/).
+[test credit cards with Stripe](/how-to/set-up-and-use-stripe/).
 
 Even after launch you can continue building new features in the
 development environment without causing disruptions to your live

--- a/src/docs/concepts-extended-data/extended-data-introduction/index.md
+++ b/src/docs/concepts-extended-data/extended-data-introduction/index.md
@@ -12,10 +12,9 @@ published: true
 
 This article explains the basics of extended data. If you want to get
 technical instead, check out the
-[Extended data API Reference](https://www.sharetribe.com/docs/references/extended-data/)
-or learn how to add extended data in
-[part two](https://www.sharetribe.com/docs/tutorial/add-extended-data/)
-of the Flex tutorial.
+[Extended data API Reference](/references/extended-data/) or learn how
+to add extended data in
+[part two of the Flex tutorial](/tutorial/add-extended-data/).
 
 ## Why extended data?
 
@@ -203,7 +202,7 @@ Extended data helps you build the custom search and filtering experience
 your marketplace needs.
 
 Listings can be searched by keyword or location using Flex’s
-[powerful built-in search feature](https://www.sharetribe.com/docs/concepts/how-the-listing-search-works/).
+[powerful built-in search feature](/concepts/how-the-listing-search-works/).
 In addition to this, you can use listing public extended data and
 metadata to create a variety of different types of filters; for example,
 a filter can be a slider with a range of values or a checkbox group. You

--- a/src/docs/concepts-listings/listings-overview/index.md
+++ b/src/docs/concepts-listings/listings-overview/index.md
@@ -23,8 +23,7 @@ the public Listing endpoints or they are only available to the listing's
 author.
 
 When tracking
-[listing events](https://www.sharetribe.com/docs/references/events/#supported-event-types)
-through the
+[listing events](/references/events/#supported-event-types) through the
 [Integration API](https://www.sharetribe.com/api-reference/integration.html),
 it is important to also pay attention to the state of the listing. For
 instance, in the default FTW template implementation the listing is

--- a/src/docs/concepts-management/manage-listings/index.md
+++ b/src/docs/concepts-management/manage-listings/index.md
@@ -44,7 +44,7 @@ Below the summary, you have separate sections for each type of extended
 data. Extended data is a Flex feature that allows you to customize and
 collect user, listing, and transaction data specific to your
 marketplace. You can read
-[an introduction to extended data](https://www.sharetribe.com/docs/concepts/extended-data-introduction/)
+[an introduction to extended data](/concepts/extended-data-introduction/)
 to learn more. All extended data can be edited directly through Console.
 You can change existing field values or even add new extended data
 fields.
@@ -52,14 +52,13 @@ fields.
 At the bottom of the listing card, you have the Events section. It
 contains a Flex CLI command that you can use to view all the events
 related to this listing. Read more about
-[viewing events with Flex CLI](https://www.sharetribe.com/docs/how-to/view-events-with-flex-cli/)
-or visit the
-[Events reference in our Docs site](https://www.sharetribe.com/docs/references/events/).
+[viewing events with Flex CLI](/how-to/view-events-with-flex-cli/) or
+visit the [Events reference in our Docs site](/references/events/).
 
 ### Listing approval
 
 If you have
-[the listing approval feature](https://www.sharetribe.com/docs/operator-guides/concepts/#listing-pending-approval)
+[the listing approval feature](/operator-guides/concepts/#listing-pending-approval)
 enabled in your marketplace, you will find the “approve listing” button
 at the bottom of the displayed section of the listing card.
 

--- a/src/docs/concepts-management/manage-overview/index.md
+++ b/src/docs/concepts-management/manage-overview/index.md
@@ -17,10 +17,10 @@ marketplace’s day-to-day operations.
 
 The section consists of four pages:
 
-- [Manage users](https://www.sharetribe.com/docs/concepts/console-manage-users/)
-- [Manage listings](https://www.sharetribe.com/docs/concepts/console-manage-listings/)
-- [Manage transactions](https://www.sharetribe.com/docs/concepts/console-manage-transactions/)
-- [Manage reviews](https://www.sharetribe.com/docs/concepts/console-manage-reviews/)
+- [Manage users](/concepts/console-manage-users/)
+- [Manage listings](/concepts/console-manage-listings/)
+- [Manage transactions](/concepts/console-manage-transactions/)
+- [Manage reviews](/concepts/console-manage-reviews/)
 
 On these pages, you can manage, add, and edit your user, listing,
 transaction, and review data. The information you can add and edit
@@ -40,5 +40,4 @@ You can also perform marketplace admin actions on the Manage pages.
 On each page, you can download the data in CSV format.
 
 If you’d like to learn more about operating a marketplace in Console, we
-recommend this
-[overview of Flex Console](https://www.sharetribe.com/docs/concepts/console-overview/).
+recommend this [overview of Flex Console](/concepts/console-overview/).

--- a/src/docs/concepts-management/manage-reviews/index.md
+++ b/src/docs/concepts-management/manage-reviews/index.md
@@ -10,7 +10,7 @@ published: true
 ## Review card
 
 Reviews, as
-[other elements of your marketplace Console](https://www.sharetribe.com/docs/concepts/console-manage-overview/),
+[other elements of your marketplace Console](/concepts/console-manage-overview/),
 are displayed in cards.
 
 ![Review card](./review-card.png)
@@ -45,6 +45,5 @@ You can edit the text and rating directly in Console.
 At the bottom of the review card, you find the Events section. It
 contains a Flex CLI command that you can use to view all the events
 related to this review. Read more about
-[viewing events with Flex CLI](https://www.sharetribe.com/docs/how-to/view-events-with-flex-cli/)
-or visit the
-[Events reference in our Docs site](https://www.sharetribe.com/docs/references/events/).
+[viewing events with Flex CLI](/how-to/view-events-with-flex-cli/) or
+visit the [Events reference in our Docs site](/references/events/).

--- a/src/docs/concepts-management/manage-transactions/index.md
+++ b/src/docs/concepts-management/manage-transactions/index.md
@@ -39,26 +39,25 @@ The summary includes most of the information about the transaction.
 
 - Booking status: If your transaction process uses availability, the
   transaction will be in one of
-  [the different booking statuses](https://www.sharetribe.com/docs/references/transaction-process-actions/#bookings).
+  [the different booking statuses](/references/transaction-process-actions/#bookings).
   The booking status is different from the transaction status.
 - Booking period: If your transaction uses availability, the booking
   period will be the timeframe of this transaction. In case of a rental
   marketplace, it will be the rental period of a sauna, for example.
 - Seats: If your listing has a specific number of
-  [seats](https://www.sharetribe.com/docs/references/availability/#seats)
-  available, you will see how many seats were booked as a part of this
-  transaction.
+  [seats](/references/availability/#seats) available, you will see how
+  many seats were booked as a part of this transaction.
 - Stock reservation status: If your transaction process uses stock, the
   stock reservation can be in one of the different
-  [stock reservations states](https://www.sharetribe.com/docs/references/stock/#stock-reservation-states).
+  [stock reservations states](/references/stock/#stock-reservation-states).
 - Stock reservation quantity: The amount of stock reserved in this
   transaction.
 - Transaction ID: Unique ID of the transaction in the Flex database.
 - Transaction process: You can have multiple
-  [transaction processes](https://www.sharetribe.com/docs/concepts/transaction-process/)
-  active in your marketplace and each transaction process can have
-  multiple versions. This field specifies which process and which
-  version the transaction uses.
+  [transaction processes](/concepts/transaction-process/) active in your
+  marketplace and each transaction process can have multiple versions.
+  This field specifies which process and which version the transaction
+  uses.
 - Customer paid: This field shows how much money the customer paid. It
   also includes a breakdown of the line items and the fee that your
   marketplace collects from the buyer.
@@ -75,21 +74,21 @@ The summary includes most of the information about the transaction.
 
 In the timeline, you see all the transitions that have been triggered so
 far in the transaction as well as the time when they took place and
-[the actor who initiated each transition](https://www.sharetribe.com/docs/concepts/transaction-process/#transitions).
+[the actor who initiated each transition](/concepts/transaction-process/#transitions).
 You also see the possible next transitions. If the actor of the next
 possible transition is the Operator (you), you will be able to initiate
 that transition in the timeline section.
 
 ### Activity
 
-[All customer interactions in your marketplace](https://www.sharetribe.com/docs/concepts/transaction-process/#users-interact-through-transactions)
+[All customer interactions in your marketplace](/concepts/transaction-process/#users-interact-through-transactions)
 are considered transactions in Flex. In the activity section, you will
 see the history of the transaction. This includes all the transitions
 that have occurred already, similar to the Timeline section, interwoven
 with the communication that has happened within the transaction.
 
 The communication includes all the
-[notifications that have been sent](https://www.sharetribe.com/docs/references/transaction-process-format/#notifications)
+[notifications that have been sent](/references/transaction-process-format/#notifications)
 as a part of the transaction process, the written messages between
 users, and the reviews given at the end of the transaction, if
 available.
@@ -98,23 +97,21 @@ available.
 
 There are two separate sections for each type of extended data supported
 by transactions: protected data and metadata. You can read
-[an introduction to Extended data](https://www.sharetribe.com/docs/concepts/extended-data-introduction/)
+[an introduction to Extended data](/concepts/extended-data-introduction/)
 to learn more about different types of Extended Data. Unlike with
-[user cards](https://www.sharetribe.com/docs/concepts/console-manage-users/)
-and
-[listing cards](https://www.sharetribe.com/docs/concepts/console-manage-listings/),
-transaction public extended data cannot be edited directly through
-Console. You can change existing field values or even add new fields for
-the metadata, but, since protected data is captured at specific points
-of the transaction, it is seared in the transaction information.
-Transaction related protected data cannot be changed through Console.
+[user cards](/concepts/console-manage-users/) and
+[listing cards](/concepts/console-manage-listings/), transaction public
+extended data cannot be edited directly through Console. You can change
+existing field values or even add new fields for the metadata, but,
+since protected data is captured at specific points of the transaction,
+it is seared in the transaction information. Transaction related
+protected data cannot be changed through Console.
 
 At the bottom of the transaction card, you find the Events section. It
 contains a Flex CLI command that you can use to view all the events
 related to this transaction. Read more about
-[viewing events with Flex CLI](https://www.sharetribe.com/docs/how-to/view-events-with-flex-cli/)
-or visit the
-[Events reference in our Docs site](https://www.sharetribe.com/docs/references/events/).
+[viewing events with Flex CLI](/how-to/view-events-with-flex-cli/) or
+visit the [Events reference in our Docs site](/references/events/).
 
 ## Browse and Search transactions
 

--- a/src/docs/concepts-management/manage-users/index.md
+++ b/src/docs/concepts-management/manage-users/index.md
@@ -56,7 +56,7 @@ Below the overview, you have separate sections for each type of extended
 data. Extended data is a Flex feature that allows you to customize and
 collect user, listing, and transaction data specific to your
 marketplace. You can read
-[an introduction to extended data](https://www.sharetribe.com/docs/concepts/extended-data-introduction/)
+[an introduction to extended data](/concepts/extended-data-introduction/)
 to learn more. All extended data can be edited directly through Console.
 You can change existing field values or even add new extended data
 fields.
@@ -64,9 +64,8 @@ fields.
 At the bottom of the user card, you have the Events section. It contains
 a Flex CLI command that you can use to view all the events related to
 this user. Read more about
-[viewing events with Flex CLI](https://www.sharetribe.com/docs/how-to/view-events-with-flex-cli/)
-or visit the
-[Events reference in our Docs site](https://www.sharetribe.com/docs/references/events/).
+[viewing events with Flex CLI](/how-to/view-events-with-flex-cli/) or
+visit the [Events reference in our Docs site](/references/events/).
 
 ## Browse and search users
 

--- a/src/docs/concepts-messages/email-notifications/index.md
+++ b/src/docs/concepts-messages/email-notifications/index.md
@@ -25,13 +25,13 @@ request.
 
 Email notifications are automatically enabled in your test marketplace.
 However, in your production marketplace, you must
-[configure outgoing email settings](https://www.sharetribe.com/docs/how-to/set-up-outgoing-email-settings/)
+[configure outgoing email settings](/how-to/set-up-outgoing-email-settings/)
 for email notifications to work.
 
-Users will not receive email notifications until they have verified their
-email address. Sharetribe does not send emails to unconfirmed addresses
-to avoid people flagging those as spam emails, as that can hurt your
-marketplace's ability to send mail to legitimate users.
+Users will not receive email notifications until they have verified
+their email address. Sharetribe does not send emails to unconfirmed
+addresses to avoid people flagging those as spam emails, as that can
+hurt your marketplace's ability to send mail to legitimate users.
 
 Do note that built-in email notifications can not be disabled.
 
@@ -46,7 +46,7 @@ in the Flex Console. You can find the editor in the Console under the
 Build section.
 
 The email templates use the
-[Handlebars template language](https://www.sharetribe.com/docs/references/email-templates/#handlebars).
+[Handlebars template language](/references/email-templates/#handlebars).
 In each template, you can use a set of predefined context variables
 (such as the name and email of the recipient). You can find all context
 variables to the right of the built-in email template editor. You can
@@ -62,34 +62,34 @@ clicking on "preview" and pressing on the "Send a test email" button.
 
 For more information on how to use the Handlebars to customise email
 templates, see our
-[reference article on email templates](https://www.sharetribe.com/docs/references/email-templates/#handlebars).
+[reference article on email templates](/references/email-templates/#handlebars).
 
 ## Transaction notifications
 
 Transaction notifications inform the user of events related to the
-[transaction process](https://www.sharetribe.com/docs/concepts/transaction-process/).
-These notifications usually relate to information about bookings and
-payments, in contrast to built-in email notifications, which are
-typically actionable and related to account management.
+[transaction process](/concepts/transaction-process/). These
+notifications usually relate to information about bookings and payments,
+in contrast to built-in email notifications, which are typically
+actionable and related to account management.
 
 You can update, add, or delete transaction notifications by
-[editing the transaction process](https://www.sharetribe.com/docs/how-to/edit-transaction-process-with-flex-cli/).
+[editing the transaction process](/how-to/edit-transaction-process-with-flex-cli/).
 The
 [template sub-directory](https://github.com/sharetribe/flex-example-processes/tree/master/flex-default-process/templates)
 in the transaction process directory contains all the transaction
 notification email templates. All transaction notifications use the
-[Handlebars templating language](https://www.sharetribe.com/docs/references/email-templates/#handlebars)
+[Handlebars templating language](/references/email-templates/#handlebars)
 and can be edited similarly to built-in email templates.
 
 In addition to making changes to the content of the transaction
 notifications, you can change
-[when email notifications get sent](https://www.sharetribe.com/docs/references/transaction-process-time-expressions/).
+[when email notifications get sent](/references/transaction-process-time-expressions/).
 A transaction notification must always be associated with a specific
 transition. When a specific transition transitions, the transaction
 notification associated with it is triggered.
 
 Read more about transaction notifications in our
-[tutorial on how to add new email notifications](https://www.sharetribe.com/docs/tutorial/add-new-email-notification/).
+[tutorial on how to add new email notifications](/tutorial/add-new-email-notification/).
 
 ## Custom notifications through Zapier
 
@@ -97,19 +97,19 @@ Sometimes the built-in and transaction notifications are not enough, and
 you might need more control over what triggers an email. Examples
 include notifying your marketplace operators when a user submits a
 listing for review or sending a provider an email once their listing is
-published. As neither of these actions is transaction related, you can not
-trigger them as transaction notifications. Instead, you must listen to
-events and trigger an email to respond to the correct event.
+published. As neither of these actions is transaction related, you can
+not trigger them as transaction notifications. Instead, you must listen
+to events and trigger an email to respond to the correct event.
 
 For building custom email notifications, we recommend connecting your
 app to Zapier. You can use Zapier to listen for events in your
 marketplace and react to them using different actions. Zapier also
 supports sending text messages instead of emails. Read more about Zapier
 in our
-[guide on how to set up and use Zapier](https://www.sharetribe.com/docs/how-to/set-up-and-use-zapier/).
+[guide on how to set up and use Zapier](/how-to/set-up-and-use-zapier/).
 
-If you are unsure how to approach a Zapier integration, do not hesitate to
-reach out to our support team through one of our
-[official support channels](https://www.sharetribe.com/support/). We will
-be happy to help you figure out your specific use case and give you some
-suggestions for implementation.
+If you are unsure how to approach a Zapier integration, do not hesitate
+to reach out to our support team through one of our
+[official support channels](https://www.sharetribe.com/support/). We
+will be happy to help you figure out your specific use case and give you
+some suggestions for implementation.

--- a/src/docs/concepts-messages/messages/index.md
+++ b/src/docs/concepts-messages/messages/index.md
@@ -19,8 +19,7 @@ to be associated with a transaction and can not be sent outside of one.
 The default
 [transaction process](https://github.com/sharetribe/flex-example-processes/blob/master/flex-default-process/process.edn)
 includes an enquiry transition, which initiates a transaction without
-running any
-[actions](https://www.sharetribe.com/docs/references/transaction-process-actions/#actions),
+running any [actions](/references/transaction-process-actions/#actions),
 allowing the provider and customer to send messages to each other. Note
 that messages do not alter the transaction or transition state.
 
@@ -29,7 +28,7 @@ that messages do not alter the transaction or transition state.
 You can send messages using the
 [send message endpoint](https://www.sharetribe.com/api-reference/marketplace.html#send-message),
 which requires an authenticated user’s access token to call. The
-[Integration API](https://www.sharetribe.com/docs/introduction/getting-started-with-integration-api/)
+[Integration API](/introduction/getting-started-with-integration-api/)
 does not offer an endpoint to send messages, and therefore, only
 authenticated users can send messages through the Marketplace API.
 
@@ -43,20 +42,18 @@ included as a relationship when
 ### Email notifications
 
 New messages trigger a
-[built-in email notification](https://www.sharetribe.com/docs/concepts/email-notifications/)
-sent to the receiving party of the message. You can edit built-in email
+[built-in email notification](/concepts/email-notifications/) sent to
+the receiving party of the message. You can edit built-in email
 notifications through
 [Console](https://flex-console.sharetribe.com/email-templates/new-message).
 
 ## Zapier, events and messages
 
-Using
-[Zapier](https://www.sharetribe.com/docs/how-to/set-up-and-use-zapier/)
-you can connect your marketplace with other web applications and create
-automated workflows. Even though you can’t listen for new messages
-through Zapier, messages can easily be retrieved as a transaction
-relationship. For more complex customisations, you can use events to
-listen to new or deleted messages.
+Using [Zapier](/how-to/set-up-and-use-zapier/) you can connect your
+marketplace with other web applications and create automated workflows.
+Even though you can’t listen for new messages through Zapier, messages
+can easily be retrieved as a transaction relationship. For more complex
+customisations, you can use events to listen to new or deleted messages.
 
 ### How to retrieve messages in Zapier
 
@@ -77,19 +74,15 @@ to use the message content in your Zap.
 
 ### Events and messages
 
-Listening to
-[events](https://www.sharetribe.com/docs/cookbook-events/reacting-to-events/)
-through the
-[Integration API](https://www.sharetribe.com/docs/introduction/getting-started-with-integration-api/)
+Listening to [events](/cookbook-events/reacting-to-events/) through the
+[Integration API](/introduction/getting-started-with-integration-api/)
 is the most versatile way to react to what is happening in your
 marketplace. As sending new messages does not affect transaction state
 or transitions, you can’t use Zapier to detect new messages as it can
 only react to transactions, listing and user events. Events allow you to
-listen to
-[created messages](https://www.sharetribe.com/docs/references/events/#supported-event-types)
+listen to [created messages](/references/events/#supported-event-types)
 and react directly to them. See how to
-[react to events](https://www.sharetribe.com/docs/how-to/reacting-to-events/)
-and the
+[react to events](/how-to/reacting-to-events/) and the
 [Integration API example script repository](https://github.com/sharetribe/flex-integration-api-examples)
 if you’re unsure where to start building your integration.
 
@@ -105,8 +98,8 @@ This is how the default logic works:
 
 1.  A
     [query is made](https://github.com/sharetribe/ftw-daily/blob/master/src/ducks/user.duck.js#L300)
-    that retrieves all sales transactions (i.e. transactions where the current user is the
-    provider) transactions that are in the
+    that retrieves all sales transactions (i.e. transactions where the
+    current user is the provider) transactions that are in the
     [confirm payment state](https://github.com/sharetribe/ftw-daily/blob/85e9291a3078c54d6531ad465276f03847882911/src/util/transaction.js#L214)
 2.  The amount of sales transactions determines the
     [notification count](https://github.com/sharetribe/ftw-daily/blob/master/src/ducks/user.duck.js#L104)
@@ -124,4 +117,4 @@ new message. To achieve this, you could change the logic behind
 to display a number stored in extended data. The data attribute would
 represent the number of unread messages, and could be updated every time
 a new message is detected using
-[events](https://www.sharetribe.com/docs/cookbook-events/reacting-to-events/).
+[events](/cookbook-events/reacting-to-events/).

--- a/src/docs/concepts-payments/payments-overview/index.md
+++ b/src/docs/concepts-payments/payments-overview/index.md
@@ -108,7 +108,7 @@ with a bank account set up before others can initiate transactions with
 them successfully. This is done by
 [creating a Stripe account](https://www.sharetribe.com/api-reference/marketplace.html#create-stripe-account)
 for the authenticated user. The
-[FTW templates](https://www.sharetribe.com/docs/how-to/provider-onboarding-and-identity-verification/)
+[FTW templates](/how-to/provider-onboarding-and-identity-verification/)
 are configured to do this step out-of-the-box using
 [Stripe Connect Onboarding](https://stripe.com/en-fi/connect/onboarding).
 

--- a/src/docs/concepts-pricing-and-commissions/commissions-and-monetizing-your-platform/index.md
+++ b/src/docs/concepts-pricing-and-commissions/commissions-and-monetizing-your-platform/index.md
@@ -213,7 +213,7 @@ your marketplace and are directly supported by Flex. However, you might
 want to experiment with other monetization models depending on your
 business idea. For example, subscriptions might be a good way of
 monetizing your marketplace. With the
-[Integration API](https://www.sharetribe.com/docs/concepts/marketplace-api-integration-api/#when-to-use-the-integration-api),
+[Integration API](/concepts/marketplace-api-integration-api/#when-to-use-the-integration-api),
 you can integrate a third-party service such as
 [Chargebee](https://www.chargebee.com/) or
 [Stripe billing](https://stripe.com/en-fi/billing) to process

--- a/src/docs/concepts-pricing-and-commissions/pricing/index.md
+++ b/src/docs/concepts-pricing-and-commissions/pricing/index.md
@@ -146,7 +146,7 @@ percentage of some other (sub)total.
 ## Refunds
 
 Refunds are created with the
-[calculate-full-refund](https://www.sharetribe.com/docs/references/transaction-process-actions/#actioncalculate-full-refund)
+[calculate-full-refund](/references/transaction-process-actions/#actioncalculate-full-refund)
 action. It sets transaction pay in and pay out amounts to zero and
 creates reverse line items that undo all the previous line items. Note,
 that the `calculate-full-refund` action can be run only once during a

--- a/src/docs/concepts-transactions/change-transaction-process/index.md
+++ b/src/docs/concepts-transactions/change-transaction-process/index.md
@@ -23,10 +23,8 @@ Understanding how the transaction process works will help you be on the
 same page with your developer on what and how to build.
 
 This article continues the general overview of the transaction process
-offered
-[here](https://www.sharetribe.com/docs/concepts/transaction-process/) by
-suggesting a few principles to keep in mind when designing how your
-users will transact.
+offered [here](/concepts/transaction-process/) by suggesting a few
+principles to keep in mind when designing how your users will transact.
 
 ## What to think about in designing your own transaction process
 
@@ -108,10 +106,10 @@ about the following.
 
 To further think about the user experience on your marketplace in
 addition to transactions,
-[consult our guide](https://www.sharetribe.com/docs/design-toolkit/what-are-user-journeys/)
-on defining the discovery and listing creating process in your
-marketplace. You can see the default user experience provided by
-[Flex’s Templates for Web](https://www.sharetribe.com/docs/operator-guides/concepts/#flex-templates-for-web-ftw)
+[consult our guide](/design-toolkit/what-are-user-journeys/) on defining
+the discovery and listing creating process in your marketplace. You can
+see the default user experience provided by
+[Flex’s Templates for Web](/operator-guides/concepts/#flex-templates-for-web-ftw)
 there too.
 
 ## Draw it out
@@ -130,7 +128,7 @@ user can take as part of moving from state to state.
 
 You can draw out your transaction process with a pen and paper or online
 using a tool like
-[Whimsical](https://www.sharetribe.com/docs/concepts/change-transaction-process/#start-designing).
+[Whimsical](/concepts/change-transaction-process/#start-designing).
 
 ## Modify an existing process, if you can
 
@@ -166,14 +164,12 @@ offers. Your users will need an interface to complete these actions.
 
 Since the Flex Template does not contain such an interface out of the
 box, a developer will need to customize it into the application. You can
-use the
-[Flex design files](https://www.sharetribe.com/docs/design-toolkit/design-files/)
-to guide your developer on how you want this to work.
+use the [Flex design files](/design-toolkit/design-files/) to guide your
+developer on how you want this to work.
 
 You can review everything included in the Flex Template by exploring the
-demo marketplace in your Console. You can specifically review the
-screens that are part of a transaction
-[here](https://www.sharetribe.com/docs/design-toolkit/your-user-journey-a-guide/#transaction-process).
+demo marketplace in your Console. You can refer to this article to
+[review the screens that are part of a transaction](/design-toolkit/your-user-journey-a-guide/#transaction-process).
 
 ## Share your transaction process with your developer
 

--- a/src/docs/concepts-transactions/transaction-process/index.md
+++ b/src/docs/concepts-transactions/transaction-process/index.md
@@ -128,7 +128,7 @@ Technically, transitions can be considered the main building block of
 Flex transaction process. They define, implicitly or explicitly, all the
 other elements of a transaction process. We will not go to into more
 detail in this article, but you can find more information
-[in the transaction process format reference documentation.](https://www.sharetribe.com/docs/references/transaction-process-format/)
+[in the transaction process format reference documentation.](/references/transaction-process-format/)
 
 ### Actions
 
@@ -142,7 +142,7 @@ cancelling the booking and issuing a refund.
 
 Possible actions are defined by the capacity of the Flex API. The list
 of all transaction process actions can be found
-[in the transaction process actions reference documentation](https://www.sharetribe.com/docs/references/transaction-process-actions/).
+[in the transaction process actions reference documentation](/references/transaction-process-actions/).
 Creating custom transaction process actions is not possible in Flex.
 
 ### Notifications
@@ -162,10 +162,9 @@ notification prompting them to review the customer. The customer
 receives an email notification to review the provider.
 
 To review what notifications are sent as part of the Flex default
-process, visit your
-[Flex Console](https://www.sharetribe.com/docs/operator-guides/concepts/#console)
+process, visit your [Flex Console](/operator-guides/concepts/#console)
 Build tab. Each included
-[email notification has a template](https://www.sharetribe.com/docs/references/email-templates/#editing-transaction-emails)
+[email notification has a template](/references/email-templates/#editing-transaction-emails)
 that can be customized using the Flex CLI.
 
 <transactionprocesscomponentscarousel title="Transaction process components">
@@ -244,9 +243,9 @@ you’ll likely want to modify these to capture the unique way your users
 will transact.
 
 If you’re a developer building with Flex, you can build your transaction
-process using the Flex CLI.
-[Here is a guide](https://www.sharetribe.com/docs/tutorial/create-transaction-process/)
-for creating your own transaction process and for
+process using the Flex CLI. Here are guides for
+[creating your own transaction process](/tutorial/create-transaction-process/)
+and for
 [getting started with Flex CLI](/introduction/getting-started-with-flex-cli/).
 For more details of the transaction process format, see the
 [Transaction process format](/references/transaction-process-format/)
@@ -259,6 +258,6 @@ If you’re working with a developer, then you need to communicate how you
 would like transactions to work so your developer can implement the
 necessary steps, transitions, and actions to build your transaction
 process.
-[Our guide for changing your transaction process](https://www.sharetribe.com/docs/concepts/change-transaction-process/)
+[Our guide for changing your transaction process](/concepts/change-transaction-process/)
 shares a few principles to keep in mind when making changes as a
 non-developer.

--- a/src/docs/concepts-users-and-authentication/users-and-authentication-in-flex/index.md
+++ b/src/docs/concepts-users-and-authentication/users-and-authentication-in-flex/index.md
@@ -117,18 +117,14 @@ for custom marketplace dashboards.
 
 Flex marketplace users need to sign up with their email address to
 create listings and participate in transactions. Alternatively, they can
-use
-[social logins](https://www.sharetribe.com/docs/concepts/social-logins-and-sso/)
-to sign up, or to login with an email address that already has a user
-within Flex.
+use [social logins](/concepts/social-logins-and-sso/) to sign up, or to
+login with an email address that already has a user within Flex.
 
-Flex has a separate
-[Authentication API](https://www.sharetribe.com/docs/concepts/authentication-api/)
+Flex has a separate [Authentication API](/concepts/authentication-api/)
 that handles authentication to other Flex APIs. Both Marketplace API and
 Integration API require valid access tokens to be passed in every API
-request. If you use the
-[Javascript SDKs](https://www.sharetribe.com/docs/concepts/js-sdk/) in
-your marketplace client application, they handle authenticating the user
+request. If you use the [Javascript SDKs](/concepts/js-sdk/) in your
+marketplace client application, they handle authenticating the user
 automatically when they enter their credentials.
 
 ## Banned and deleted users
@@ -230,7 +226,7 @@ endpoints you can access using the Integration API, refer to the
 
 To access the Integration API you need a valid access token obtained
 through
-[the Authentication API](https://www.sharetribe.com/docs/concepts/authentication-api/#authentication-api)
+[the Authentication API](/concepts/authentication-api/#authentication-api)
 or the
 [Sharetribe Flex Integration SDK](https://sharetribe.github.io/flex-integration-sdk-js/authentication.html).
 You should only grant access to trusted applications, such as ones that

--- a/src/docs/design-toolkit/user-journey-saunatime/index.md
+++ b/src/docs/design-toolkit/user-journey-saunatime/index.md
@@ -74,8 +74,8 @@ happens between the listing provider and the purchasing customer.
 Sharetribe Flex lets you extensively customize the rules and steps of
 your transaction process to govern how providers and customers
 capitalize on your marketplace.
-[Saunatime’s default process](https://www.sharetribe.com/docs/concepts/transaction-process/)
-mimics an Airbnb-style daily booking rental.
+[Saunatime’s default process](/concepts/transaction-process/) mimics an
+Airbnb-style daily booking rental.
 
 <transactionprocesscarousel title="Transaction process">
 
@@ -87,6 +87,5 @@ As the development starting point, Saunatime’s user journeys are the
 default ways in which users create content, discover listings, and
 transact in Flex. Designing your marketplace’s journeys helps developers
 understand how to modify the template code to build your custom
-marketplace.
-[The next article](https://www.sharetribe.com/docs/design-toolkit/your-user-journey-a-guide/)
-guides you in creating your own user journey.
+marketplace. The next article guides you in
+[creating your own user journey](/design-toolkit/your-user-journey-a-guide/).

--- a/src/docs/design-toolkit/user-journey-sneakertime/index.md
+++ b/src/docs/design-toolkit/user-journey-sneakertime/index.md
@@ -93,5 +93,5 @@ discover listings, and transact on your custom product selling
 marketplace. Designing your own marketplace’s journeys helps developers
 understand how to modify this template starting point to build your
 custom marketplace.
-[The next article](https://www.sharetribe.com/docs/design-toolkit/your-user-journey-a-guide/)
-guides you in creating your own user journey.
+[The next article](/design-toolkit/your-user-journey-a-guide/) guides
+you in creating your own user journey.

--- a/src/docs/design-toolkit/user-journey-yogatime/index.md
+++ b/src/docs/design-toolkit/user-journey-yogatime/index.md
@@ -95,6 +95,5 @@ Yogatime offers a starting point for how users create listing profiles,
 discover providers, and transact on your custom service booking
 marketplace. Designing your own marketplace’s journeys helps developers
 understand how to modify this template starting point to build your
-custom marketplace.
-[The next article](https://www.sharetribe.com/docs/design-toolkit/your-user-journey-a-guide/)
-guides you in creating your own user journey.
+custom marketplace. The next article guides you in
+[creating your own user journey](/design-toolkit/your-user-journey-a-guide/).

--- a/src/docs/design-toolkit/your-user-journey-a-guide/index.md
+++ b/src/docs/design-toolkit/your-user-journey-a-guide/index.md
@@ -17,7 +17,7 @@ during a transaction lets you receive more accurate estimates of the
 budget required to build your custom marketplace with Flex.
 
 In
-[the previous article](https://www.sharetribe.com/docs/design-toolkit/what-are-user-journeys/#the-user-journeys-for-flex-templates),
+[the previous article](/design-toolkit/what-are-user-journeys/#the-user-journeys-for-flex-templates),
 you learned how listing creation, listing discovery, and the transaction
 process works in one of the Flex Templates. Now it is time to define how
 users complete these critical journeys on your marketplace.
@@ -83,8 +83,8 @@ completion. Consider these questions:
 - What email notifications are sent as part of the transaction process?
   When are they sent?
 
-You can learn more about the transaction process functionality in Flex
-[in this overview article](https://www.sharetribe.com/docs/concepts/transaction-process/).
+Learn more about
+[the transaction process functionality in Flex](/concepts/transaction-process/).
 
 ## 2. Create maps for listing creation journey, discovery journey and transaction process.
 

--- a/src/docs/ftw-introduction/ftw-customization-checklist/index.md
+++ b/src/docs/ftw-introduction/ftw-customization-checklist/index.md
@@ -73,9 +73,8 @@ FTW.
 
 ## 4. Other optional changes
 
-- **Update
-  [page schema](https://www.sharetribe.com/docs/tutorial/add-faq-page/#page-schema)**
-  to improve Search Engine Optimization (SEO)
+- **Update [page schema](/tutorial/add-faq-page/#page-schema)** to
+  improve Search Engine Optimization (SEO)
 - **Update ListingPage** to show extended data (aka publicData
   attribute).
   - It's inside _src/containers_ directory

--- a/src/docs/howto-migrations/go-to-flex-migration/index.md
+++ b/src/docs/howto-migrations/go-to-flex-migration/index.md
@@ -51,19 +51,16 @@ organization (your organization is displayed in your
 - Price (as an number amount)
 - Location
 - Images
-- Custom fields (as listing
-  [public data](https://www.sharetribe.com/docs/references/extended-data/))
-- Categories (as listing
-  [public data](https://www.sharetribe.com/docs/references/extended-data/))
+- Custom fields (as listing [public data](/references/extended-data/))
+- Categories (as listing [public data](/references/extended-data/))
 
 _What is not migrated automatically: order type data, shipping price,
 comments, and availability calendar data. In Flex, the
-[transaction process](https://www.sharetribe.com/docs/concepts/transaction-process/)
-determines how price is calculated and how the order flow works. If you
-have enabled multiple order types or shipping price in Go and want to
-migrate the data from these over to Flex, you need to do custom
-development to ensure the data is transferred and displayed correctly.
-application._
+[transaction process](/concepts/transaction-process/) determines how
+price is calculated and how the order flow works. If you have enabled
+multiple order types or shipping price in Go and want to migrate the
+data from these over to Flex, you need to do custom development to
+ensure the data is transferred and displayed correctly. application._
 
 #### User profiles:
 
@@ -73,8 +70,7 @@ application._
 - Primary email address
 - Password hashes (so user can use same credentials to login)
 - Profile image
-- Phone number (as user
-  [protected data](https://www.sharetribe.com/docs/references/extended-data/))
+- Phone number (as user [protected data](/references/extended-data/))
 - Stripe accounts
 
 _Migrated profiles do not include username, custom user field data,

--- a/src/docs/howto-migrations/migrating-from-outside-sharetribe/index.md
+++ b/src/docs/howto-migrations/migrating-from-outside-sharetribe/index.md
@@ -11,7 +11,7 @@ Data from an existing marketplace can be migrated to Sharetribe Flex. If
 your marketplace is running in Sharetribe Go, there is a ready migration
 path that will be handled by us. We will handle the migration in this
 case and you can find the outline for this process
-[here](https://www.sharetribe.com/docs/how-to/go-to-flex-migration/).
+[here](/how-to/go-to-flex-migration/).
 
 If you are running a marketplace outside the Sharetribe ecosystem, and
 would like to import data to Flex, it is possible. You will need to

--- a/src/docs/howto-search/manage-search-schemas-with-flex-cli/index.md
+++ b/src/docs/howto-search/manage-search-schemas-with-flex-cli/index.md
@@ -163,7 +163,7 @@ User profile search schema can be useful, if you have an Integration API
 application that needs to query different sets of users, depending on
 some value in the user profile's extended data. For instance, if users
 have `age` attribute stored in their protected data, you can use the
-[/users/query endpoint in the Integration API](https://www.sharetribe.com/docs/references/extended-data/)
+[/users/query endpoint in the Integration API](/references/extended-data/)
 to find users of a certain age range.
 
 Search schema for user profiles can be added as follows:

--- a/src/docs/introduction/how-to-launch/index.md
+++ b/src/docs/introduction/how-to-launch/index.md
@@ -121,7 +121,7 @@ what kind of user interface you need to accommodate the design.
 Once you have the wireframes ready and know what you want, the next step
 is to build the actual visual design. If you're comfortable with using a
 design tool like [Sketch](https://www.sketch.com/), you can
-[download the Sketch design files of FTW](https://www.sharetribe.com/docs/design-toolkit/design-files/#assets)
+[download the Sketch design files of FTW](/design-toolkit/design-files/#assets)
 and build your own design by adjusting these files. This approach can
 dramatically speed up the design process, and it offers an easy starting
 point for the developers.

--- a/src/docs/introduction/introducing-sneakertime/index.md
+++ b/src/docs/introduction/introducing-sneakertime/index.md
@@ -15,10 +15,9 @@ point for the development of product marketplaces. It offers basic
 product marketplace functionality out of the box and can be further
 customized to fit your marketplace’s unique workflows and design.
 
-To learn more, check out the video below or read on. For more technical
-information on Sneakertime, check out
-[this article](https://www.sharetribe.com/docs/ftw/ftw-product/) in our
-developer documentation.
+To learn more, check out the video below or read on. For
+[more technical information on Sneakertime](/ftw/ftw-product/), check
+out our developer documentation.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/XUpxn_K4Mm8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -60,9 +59,8 @@ search with a simple configuration change.
 ## Inventory management
 
 Inventory management is vital for product marketplaces, and Sneakertime
-uses Flex’s listing stock management features to enable it. You can read
-more about inventory management in Flex
-[in this article](https://www.sharetribe.com/docs/concepts/inventory-management/).
+uses Flex’s listing stock management features to enable it. Read more
+about [inventory management in Flex](/concepts/inventory-management/).
 
 In Sneakertime, the seller adds the number of items they have in stock
 during listing creation. When a buyer makes a purchase, that number is
@@ -121,8 +119,7 @@ each other.
 With Flex, you can modify your marketplace’s transaction flow to your
 specifications. For example, you could add a step for the seller to
 confirm the order or only have the buyer review the purchase. Read more
-about transaction processes in Flex
-[here](https://www.sharetribe.com/docs/concepts/transaction-process/).
+about [transaction processes in Flex](/concepts/transaction-process/).
 
 ## How to get started
 
@@ -135,5 +132,5 @@ If you’re a developer or have one in your team, head over to Github,
 download the Sneakertime code, and start developing your unique product
 marketplace. If you’re looking to hire a developer from Sharetribe’s
 [Expert Partner Network](https://www.sharetribe.com/experts/), check out
-[this article](https://www.sharetribe.com/docs/operator-guides/how-to-hire-developer/)
-for more information on the process.
+[this article](/operator-guides/how-to-hire-developer/) for more
+information on the process.

--- a/src/docs/introduction/introducing-yogatime/index.md
+++ b/src/docs/introduction/introducing-yogatime/index.md
@@ -11,19 +11,19 @@ published: true
 ---
 
 When working with Flex, you have the option to start development on top
-of our
-[Flex Templates for Web](https://www.sharetribe.com/docs/ftw/how-to-customize-ftw/),
-web applications built on top of the Marketplace API. You can also
-develop your frontend application from scratch, but using one of our
-templates can save considerable time.
+of our [Flex Templates for Web](/ftw/how-to-customize-ftw/), web
+applications built on top of the Marketplace API. You can also develop
+your frontend application from scratch, but using one of our templates
+can save considerable time.
 
 Yogatime or FTW-hourly is a Flex Template with time-based availability,
 built with service marketplaces in mind. Yogatime has three features
 that set it apart from other Flex templates: hourly bookings, profiles
 as bookable listings, and timezone support. You can learn more about it
 in the video below. If you prefer reading, scroll past the video, and
-read on instead! For more technical information on Yogatime, check out
-[this article](https://www.sharetribe.com/docs/ftw/ftw-hourly/).
+read on instead! For
+[more technical information on Yogatime](/ftw/ftw-hourly/), check out
+our developer documentation.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/vbw6_wm9E4g" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -65,7 +65,7 @@ Only the latter can be shown in search results.
 A provider can only create one listing, which means that all their
 bookings and availability management happen in the same place. With
 custom development, you can still
-[enable multiple listings per provider](https://www.sharetribe.com/docs/ftw/ftw-hourly/#each-provider-can-have-only-one-listing).
+[enable multiple listings per provider](/ftw/ftw-hourly/#each-provider-can-have-only-one-listing).
 
 ## Timezone support
 
@@ -91,5 +91,4 @@ and get developing.
 
 If you’re not a developer, we’re happy to connect you with a qualified
 Flex expert to build your marketplace. Take a look at
-[this article](https://www.sharetribe.com/docs/operator-guides/how-to-hire-developer/)
-to learn more!
+[this article](/operator-guides/how-to-hire-developer/) to learn more!

--- a/src/docs/operator-guides/hiring-developer-to-build-your-flex-marketplace/index.md
+++ b/src/docs/operator-guides/hiring-developer-to-build-your-flex-marketplace/index.md
@@ -11,10 +11,10 @@ published: true
 
 Sharetribe Flex allows you to build a unique marketplace fast with
 custom development. Unless you have
-[these development skills](https://www.sharetribe.com/docs/introduction/development-skills/),
-you need to hire someone who does. Though any developer will do, we
-recommend hiring a vetted developer from Sharetribe's official Flex
-Expert Network for great quality work.
+[these development skills](/introduction/development-skills/), you need
+to hire someone who does. Though any developer will do, we recommend
+hiring a vetted developer from Sharetribe's official Flex Expert Network
+for great quality work.
 
 Hiring a developer to build your marketplace with Flex requires two
 things. First communicating your requirements to the developer. Second,
@@ -28,7 +28,7 @@ marketplace. This means the developers you hire need guidance on how
 exactly you want the marketplace to work.
 
 We recommend using one of
-[Flex Templates for Web](https://www.sharetribe.com/docs/operator-guides/concepts/#flex-templates-for-web-ftw)
+[Flex Templates for Web](/operator-guides/concepts/#flex-templates-for-web-ftw)
 as a basis for the development work, especially if you're launching a
 marketplace for the first time. The Flex Templates are examples of fully
 functional marketplace applications. Typically the Templates have
@@ -45,16 +45,15 @@ what it offers. There are a few ways to gain this understanding:
    adding listings, making bookings and payments, sending messages,
    leaving reviews, and so on.
 2. Study
-   [how listing search, listing creation, and transactions work](https://www.sharetribe.com/docs/design-toolkit/what-are-user-journeys/#the-user-journeys-for-flex-templates)
+   [how listing search, listing creation, and transactions work](/design-toolkit/what-are-user-journeys/#the-user-journeys-for-flex-templates)
    specifically.
-3. Install one of the template applications (Saunatime, Yogatime, or
-   Sneakertime) yourself following
-   [this guide](https://www.sharetribe.com/docs/introduction/getting-started-with-ftw-daily/),
+3. Install one of the
+   [template applications (Saunatime, Yogatime, or Sneakertime) yourself](/introduction/getting-started-with-ftw-daily/),
    or ask a developer to do it for you.
 4. If you're comfortable working with design software like Sketch, Adobe
    XD or Figma, you can download the complete
-   [design files](https://www.sharetribe.com/docs/design-toolkit/design-files/)
-   of the two templates to explore all their pages and views.
+   [design files](/design-toolkit/design-files/) of the two templates to
+   explore all their pages and views.
 
 Your developer’s job is to customize the Flex Template (how it looks and
 how it works) to meet your unique requirements. Your responsibility is
@@ -69,7 +68,7 @@ and so on), and how buyers and sellers transact (is there an online
 payment, messaging, reviews, and so on). Whenever there's a difference
 in what you see in the template and how you want your marketplace to
 work, you need to communicate this to the developer. You can follow
-[this guide](https://www.sharetribe.com/docs/design-toolkit/your-user-journey-a-guide/)
+[this user journey guide](/design-toolkit/your-user-journey-a-guide/)
 for help.
 
 You also need to communicate to the developers how the marketplace looks

--- a/src/docs/tutorial-branding/customize-amenities-filter/index.md
+++ b/src/docs/tutorial-branding/customize-amenities-filter/index.md
@@ -178,8 +178,8 @@ For example, you could add filter for public data field `view`:
 ```
 
 Note: this assumes that you have added 'view' to the
-[extended data](https://www.sharetribe.com/docs/references/extended-data/)
-of the listing entity through the `EditListingFeaturesPanel` component.
+[extended data](/references/extended-data/) of the listing entity
+through the `EditListingFeaturesPanel` component.
 
 Read more from the article:
 [Change search filters in FTW](/how-to/change-search-filters-in-ftw/)

--- a/src/docs/tutorial-branding/deploy-to-heroku/index.md
+++ b/src/docs/tutorial-branding/deploy-to-heroku/index.md
@@ -48,10 +48,10 @@ environment, the "window" object is not available.
 
 ## Enable HTTP basic access authentication
 
-You can enforce access control in your web application by enabling HTTP 
-basic access authentication. It's a good idea to restrict access to your 
-web application while still testing your marketplace: it prevents your 
-site from being indexed in search engines and users from accidentally 
+You can enforce access control in your web application by enabling HTTP
+basic access authentication. It's a good idea to restrict access to your
+web application while still testing your marketplace: it prevents your
+site from being indexed in search engines and users from accidentally
 signing up in a marketplace still under development.
 
 FTW exposes two environment variables with which you can set a username
@@ -121,9 +121,9 @@ Then add the following environment variables as Config Vars:
 
 - `NODE_ENV`
 
-  Defines whether the application is run in production or development mode. Use
-  'development' for development and 'production' for production.<br/>
-  Use value: 'production'
+  Defines whether the application is run in production or development
+  mode. Use 'development' for development and 'production' for
+  production.<br/> Use value: 'production'
 
 - `REACT_APP_ENV`
 

--- a/src/docs/tutorial-transaction-process/create-transaction-process/index.md
+++ b/src/docs/tutorial-transaction-process/create-transaction-process/index.md
@@ -58,7 +58,7 @@ booking.
 ### Create a new process
 
 To get up and running with Flex CLI, see the
-[Getting started with Flex CLI](https://www.sharetribe.com/docs/introduction/getting-started-with-flex-cli/)
+[Getting started with Flex CLI](/introduction/getting-started-with-flex-cli/)
 guide in Flex Docs.
 
 Let's see what the subcommand `help` gives us about `process create`:

--- a/src/docs/tutorial-transaction-process/customize-pricing/index.md
+++ b/src/docs/tutorial-transaction-process/customize-pricing/index.md
@@ -385,7 +385,7 @@ attributes a line total is calculated for each line item. Line totals
 then define the total payin and payout sums of the transaction.
 
 You can read more about line items and pricing from
-[pricing background article](https://www.sharetribe.com/docs/concepts/pricing/).
+[pricing background article](/concepts/pricing/).
 
 </extraInfo>
 

--- a/src/docs/tutorial-transaction-process/use-protected-data-in-emails/index.md
+++ b/src/docs/tutorial-transaction-process/use-protected-data-in-emails/index.md
@@ -156,7 +156,7 @@ we should be able to find configuration for the _transition/accept_.
 
 To reveal the provider's protected data, we add a new action to that
 transition:
-<br/>[action/reveal-provider-protected-data](https://www.sharetribe.com/docs/references/transaction-process-actions/#actionreveal-provider-protected-data)
+<br/>[action/reveal-provider-protected-data](/references/transaction-process-actions/#actionreveal-provider-protected-data)
 
 In addition, we add configuration to that action. The **key-mapping**
 means that we just take _:phoneNumber_ from the provider's protected
@@ -206,7 +206,7 @@ To test the protected data using Flex CLI's built-in preview
 functionality, you need to use custom sample-template-context.json.
 
 You can read more from the Flex CLI article:
-[Edit email templates with Flex CLI](https://www.sharetribe.com/docs/how-to/edit-email-templates-with-flex-cli/#sample-email-context)
+[Edit email templates with Flex CLI](/how-to/edit-email-templates-with-flex-cli/#sample-email-context)
 
 The short guide of the necessary steps:
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3050,6 +3050,14 @@ babel-preset-gatsby@^2.6.0:
     gatsby-core-utils "^3.6.0"
     gatsby-legacy-polyfills "^2.6.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 backo2@^1.0.2, backo2@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
@@ -3888,6 +3896,11 @@ core-js-pure@^3.20.2:
   version "3.20.3"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.20.3.tgz#6cc4f36da06c61d95254efc54024fe4797fd5d02"
   integrity sha512-Q2H6tQ5MtPtcC7f3HxJ48i4Q7T9ybPKgvWyuH7JXIoNa2pm0KuBnycsET/qw1SLLZYfbsbrZQNMeIOClb+6WIA==
+
+core-js@^2.4.0:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.17.2:
   version "3.20.3"
@@ -5898,6 +5911,16 @@ gatsby-remark-copy-linked-files@^5.10.0:
     probe-image-size "^7.0.0"
     unist-util-visit "^2.0.3"
 
+gatsby-remark-external-links@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-external-links/-/gatsby-remark-external-links-0.0.4.tgz#85b98c1e9dacfaa58085319648c904ff3cab42f0"
+  integrity sha512-JIKZguAGoGlzsJusfCb4JKM5E6JUEDbtlBkbErt7CdMnfBP+AldZeMQEQWK5xsJ5uXCyc4qqcBWR8vp0afFpOw==
+  dependencies:
+    babel-runtime "^6.26.0"
+    is-relative-url "^2.0.0"
+    unist-util-find "^1.0.1"
+    unist-util-visit "^1.1.3"
+
 gatsby-remark-images@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-6.6.0.tgz#4fd5b26715dace7f0308cb356ec9b4a9cf3cacfe"
@@ -6928,6 +6951,11 @@ human-signals@^3.0.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
   integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
 
+husky@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -7095,6 +7123,11 @@ ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+is-absolute-url@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
+  integrity sha512-vOx7VprsKyllwjSkLV79NIhpyLfr3jAp7VaTCMXOJHu4m0Ew1CZ2fcjASwmV1jI3BWuWHB013M48eyeldk9gYg==
 
 is-absolute-url@^3.0.0:
   version "3.0.3"
@@ -7421,6 +7454,13 @@ is-regex@^1.1.4:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-relative-url@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-relative-url/-/is-relative-url-2.0.0.tgz#72902d7fe04b3d4792e7db15f9db84b7204c9cef"
+  integrity sha512-UMyEi3F+Rvjpc29IAQQ5OuMoKylt8npO0eQdXPQ2M3A5iFvh1qG+MtiLQR2tyHcVVsqwWrQiztjPAe9hnSHYeQ==
+  dependencies:
+    is-absolute-url "^2.0.0"
 
 is-relative-url@^3.0.0:
   version "3.0.0"
@@ -7993,6 +8033,11 @@ lodash.get@^4:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.iteratee@^4.5.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz#be4177db289a8ccc3c0990f1db26b5b22fc1554c"
+  integrity sha512-yv3cSQZmfpbIKo4Yo45B1taEvxjNvcpF1CEOc0Y6dEyvhPIfEJE3twDwPgWTPQubcSgXyBwBKG6wpQvWMDOf6Q==
 
 lodash.map@^4.6.0:
   version "4.6.0"
@@ -10349,6 +10394,11 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
 regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
@@ -12152,6 +12202,14 @@ unist-builder@^2.0.0:
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
 
+unist-util-find@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-find/-/unist-util-find-1.0.2.tgz#4d5b01a69fca2a382ad4f55f9865e402129ecf56"
+  integrity sha512-ft06UDYzqi9o9RmGP0sZWI/zvLLQiBW2/MD+rW6mDqbOWDcmknGX9orQPspfuGRYWr8eSJAmfsBcvOpfGRJseA==
+  dependencies:
+    lodash.iteratee "^4.5.0"
+    unist-util-visit "^1.1.0"
+
 unist-util-generated@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.5.tgz#1e903e68467931ebfaea386dae9ea253628acd42"
@@ -12232,7 +12290,7 @@ unist-util-visit-parents@^3.1.1:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit@^1.3.0:
+unist-util-visit@^1.1.0, unist-util-visit@^1.1.3, unist-util-visit@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==


### PR DESCRIPTION
Add 'gatsby-remark-external-links' plugin to open external links in new tab by default. Update absolute internal /docs/ links to relative links, and improve anchor text semantics where applicable.