### PR TITLE
Remove references to deprecated pricing articles

### DIFF
--- a/src/docs/concepts-pricing-and-commissions/commissions-and-monetizing-your-platform/index.md
+++ b/src/docs/concepts-pricing-and-commissions/commissions-and-monetizing-your-platform/index.md
@@ -11,11 +11,6 @@ ingress:
 published: true
 ---
 
-_**NOTE! The current default method for setting commissions has
-deprecated our old commission setting actions. If you are looking for
-the old commissions and monetization background article, it can be found
-[here](https://5ee94c280d38f10008a3bfa1--sharetribe-flex-docs-site.netlify.app/docs/background/commissions-and-monetizing-your-platform/).**_
-
 ## Introduction
 
 If you have already defined a pricing model for your marketplace, this

--- a/src/docs/concepts-pricing-and-commissions/pricing/index.md
+++ b/src/docs/concepts-pricing-and-commissions/pricing/index.md
@@ -10,11 +10,6 @@ ingress:
 published: true
 ---
 
-_**NOTE! The current default pricing method has deprecated our old
-custom pricing feature. If you are looking for the old custom pricing
-background article, it can be found
-[here](https://5ee94c280d38f10008a3bfa1--sharetribe-flex-docs-site.netlify.app/docs/background/custom-pricing/).**_
-
 ## What kind of pricing can you achieve with Flex
 
 It's common for a marketplace to base it's pricing on the length of a

--- a/src/docs/concepts-transactions/privileged-transitions/index.md
+++ b/src/docs/concepts-transactions/privileged-transitions/index.md
@@ -9,12 +9,6 @@ ingress:
 published: true
 ---
 
-_**NOTE! Privileged transitions enable highly flexible pricing schemes,
-deprecating our custom pricing feature that was in the past used for
-price customizations. If you are looking for the old custom pricing
-article, it can be found
-[here](https://5ee94c280d38f10008a3bfa1--sharetribe-flex-docs-site.netlify.app/docs/background/custom-pricing/).**_
-
 ## What are privileged transitions?
 
 In Flex, a process transition is an edge between two states in the

--- a/src/docs/howto-payments/customize-pricing/index.md
+++ b/src/docs/howto-payments/customize-pricing/index.md
@@ -10,12 +10,6 @@ ingress:
 published: true
 ---
 
-_**NOTE! In case your pricing relies on the deprecated
-[set-line-items-and-total](/references/transaction-process-actions/#actionset-line-items-and-total)
-action, the old pricing customization article related to that can be
-found
-[here](https://5ee94c280d38f10008a3bfa1--sharetribe-flex-docs-site.netlify.app/docs/cookbook-payments/customize-pricing).**_
-
 This how-to guide shows you how listing pricing can be customized by
 using two examples: adding a cleaning fee to a listing and changing
 provider commission so that it's based on booking length. The changes


### PR DESCRIPTION
Deploy preview in link is no longer available. Remove references to link.