### PR TITLE
fix autoscroll bug

### DIFF
--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -153,7 +153,10 @@ const SideBarStaticQuery = props => {
         window.innerWidth > DESKTOP_LAYOUT_WIDTH &&
         currentArticleLinkItem
       ) {
-        currentArticleLinkItem.scrollIntoView({ block: 'center' });
+        currentArticleLinkItem.scrollIntoView({
+          block: 'nearest',
+          inline: 'start',
+        });
       }
     }
     // We don't want to rerender every time sidebarNavsIsOpen changes.


### PR DESCRIPTION
Changes [scrollIntoView()](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) option "block" to "nearest" instead of "center". Using the center option forced the menu bar to scroll too much in links positioned towards the end of the navigation, forcing the main window to scroll in addition to the navigation bar. However, this approach sometimes positions the active link in the scroll bar at the very bottom of the browser window. From a UI standpoint, this is a bit of a compromise.

I looked into writing some custom logic by calculating the window height and the positioning of the current element in relationship to the containing element, but it started to get unnecessarily complex, and I encountered a bunch of annoying edge cases. I'm not sure if it's worth researching a solution that covers all edge cases.