### PR TITLE
Update assets structure and fix formatting

### DIFF
--- a/src/docs/concepts-messages/email-notifications/index.md
+++ b/src/docs/concepts-messages/email-notifications/index.md
@@ -37,8 +37,8 @@ You can disable some email notifications through Console.
 
 ## Built-in email notifications
 
-There are ten built-in email notifications, related
-to end-users' account management, permissions, and listings approval. Use the
+There are ten built-in email notifications, related to end-users'
+account management, permissions, and listings approval. Use the
 [Console](https://console.sharetribe.com/) to manage the built-in email
 notifications.
 
@@ -47,8 +47,8 @@ Console > Build > Content > Email texts.
 
 You can preview and customise built-in emails using the
 [Built-in email notifications editor](https://console.sharetribe.com/advanced/email-notifications)
-in the Sharetribe Console. You can find the editor in Console under
-the Build > Advanced > Email notifications section.
+in the Sharetribe Console. You can find the editor in Console under the
+Build > Advanced > Email notifications section.
 
 These built-in email notifications can be disabled through Console:
 

--- a/src/docs/concepts-payments/payments-overview/index.md
+++ b/src/docs/concepts-payments/payments-overview/index.md
@@ -363,8 +363,8 @@ troubleshoot the problem.
   check if someone has already solved a similar problem.
 
 - In case of payout problem issues, you can check out our article about
-  [Stripe payout issues](https://www.sharetribe.com/help/en/articles/10006947) for advice
-  or ideas.
+  [Stripe payout issues](https://www.sharetribe.com/help/en/articles/10006947)
+  for advice or ideas.
 
 If nothing seems to work, you can always contact Sharetribe technical
 support through the chat widget in your
@@ -407,8 +407,8 @@ causing payout issues for completely unrelated transactions; Stripe does
 not separate funds by PaymentIntent, so a miscalculated excessive refund
 on a transaction between provider A and customer B may cause payout to
 fail for customer C on a different transaction. You can read more on
-[payout issues on manual refunds](https://www.sharetribe.com/help/en/articles/10006947) to
-figure out what you would need to consider to implement this option
+[payout issues on manual refunds](https://www.sharetribe.com/help/en/articles/10006947)
+to figure out what you would need to consider to implement this option
 successfully.
 
 #### Full third party payment integration

--- a/src/docs/howto-listing/seats/index.md
+++ b/src/docs/howto-listing/seats/index.md
@@ -13,8 +13,8 @@ published: true
 
 Seats handling is included in the default functionality for bookable
 listings starting from version
-[v6.3.0](https://github.com/sharetribe/web-template/releases/tag/v6.3.0) of the
-Sharetribe Web Template
+[v6.3.0](https://github.com/sharetribe/web-template/releases/tag/v6.3.0)
+of the Sharetribe Web Template
 
 This guide applies exclusively to Sharetribe Web Template versions
 earlier than

--- a/src/docs/introduction/getting-started-with-flex-cli/index.md
+++ b/src/docs/introduction/getting-started-with-flex-cli/index.md
@@ -78,7 +78,9 @@ flex-cli help login
 
 To log in you need to have a personal API key.
 
-To get an API key, log in to Console then click your email address in the bottom left of the sidebar and click [Manage API keys](https://console.sharetribe.com/api-keys).
+To get an API key, log in to Console then click your email address in
+the bottom left of the sidebar and click
+[Manage API keys](https://console.sharetribe.com/api-keys).
 
 ## Log in
 

--- a/src/docs/references/assets/index.md
+++ b/src/docs/references/assets/index.md
@@ -1,7 +1,7 @@
 ---
 title: Assets
 slug: assets
-updated: 2023-10-24
+updated: 2025-01-29
 category: references
 ingress: Reference documentation providing information on assets.
 published: true
@@ -162,9 +162,12 @@ by default are the following:
 
 ### Transactions
 
-- Commission: `/transactions/commission.json`
 - Minimum transaction size:
   `/transactions/minimum-transaction-size.json`
+
+### Monetization
+
+- Commission: `/transactions/commission.json`
 
 ### Integrations
 

--- a/src/docs/references/email-templates/index.md
+++ b/src/docs/references/email-templates/index.md
@@ -20,8 +20,8 @@ The platform sends two types of emails:
 
 The built-in emails can be customized using the
 [Built-in email notifications editor](https://console.sharetribe.com/advanced/email-notifications)
-in the Sharetribe Console. You find the editor in Console under
-Build > Advanced > Email notifications section.
+in the Sharetribe Console. You find the editor in Console under Build >
+Advanced > Email notifications section.
 
 To change the transaction emails, follow the
 [Edit email templates with Sharetribe CLI](/how-to/edit-email-templates-with-sharetribe-cli/)


### PR DESCRIPTION
This PR updates the headings for default assets to correspond to the headings where those assets are modified in Console (in [/references/assets/index.md](https://github.com/sharetribe/flex-docs/pull/869/files#diff-355989deba881861dc38945d9e84b18b50d92b7e32c9d96753d38649b839d3ea)). In addition, some files were not formatted according to `yarn run format`, so updating those in this PR as well.