### PR TITLE
Commented out references to creating a complex attribute until they are updated

### DIFF
--- a/src/docs/howto-listing/extend-listing-data-in-ftw/index.md
+++ b/src/docs/howto-listing/extend-listing-data-in-ftw/index.md
@@ -54,9 +54,10 @@ for adding extended data directly to a listing. You will also need to
 make custom changes to your listing page, if you want to show the
 attribute there.
 
-In this article, we will first extend top-level data using
-**configListing.js**. Then, we will add a JSON attribute in extended
-data.
+In this article, we will <!-- first --> extend top-level data using
+**configListing.js**.
+<!-- Then, we will add a JSON attribute in extended
+data. -->
 
 ## Add a new top-level attribute
 
@@ -207,7 +208,7 @@ And that is it! With this configuration, the attribute can be added to
 the listing, used for search, and shown on the listing page. Next, we
 will add a complex JSON attribute that is not used for filtering.
 
-## Add a new complex attribute
+<!-- ## Add a new complex attribute
 
 You may want to add more complex attributes as well. We will add an
 attribute **lastServiced**, which will be included in a listing selling
@@ -815,6 +816,7 @@ And voilà, we have listing service history presented in the listing
 page!
 
 ![Show the service history on the listing page](./service_history_listing_page.png)
+ -->
 
 <info>
 


### PR DESCRIPTION
Original issue report, copied from [slack message](https://sharetribe.slack.com/archives/C08JPCQ18RW/p1747054210083379):

>I think we should maybe hide the [Extend listing data in template](https://www.sharetribe.com/docs/how-to/extend-listing-data-in-template/) how-to for now. It's outdated and can't be completed as-is without doing a fair bit of digging/workaround.
Was planning to wrap this one up today but spent too much time investigating
Specifically:
[FieldInputDate has been removed](https://github.com/sharetribe/web-template/commit/114a5512f575b1051c89a3b4a6c35f8eb0f1aa0e)
[React-dates has been removed](https://github.com/sharetribe/web-template/releases/tag/v6.0.0)

Agreement was to just hide the 'Complex' extended data portion of the tutorial from view until it would be updated. Have only commented out the code in the PR, but can remove it entirely if this is the preference!